### PR TITLE
Fix a test failure on Linux-x86_64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ env:
   - TARGET="Linux-X86_64" LLGS_TESTS="1"
 
 matrix:
-  allow_failures:
-    - env: TARGET="Linux-X86_64" LLGS_TESTS="1"
   fast_finish: true
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
   - if [ "$TARGET" = "Linux-ARM" ];     then sudo add-apt-repository -y ppa:linaro-maintainers/toolchain; fi
   - if [ "$TARGET" = "Linux-X86" ];     then sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test;      fi
   - if [ "$TARGET" = "Linux-X86_64" ];  then sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test;      fi
-  - if [ "$LLGS_TESTS" = "1" ];         then sudo add-apt-repository -y ppa:andykimpe/cmake;              fi
+  - sudo add-apt-repository -y ppa:andykimpe/cmake
   - sudo apt-get update
 
 install:
@@ -24,10 +24,10 @@ install:
   - if [ "$TARGET" = "Linux-ARM" ];     then sudo apt-get install -y g++-arm-linux-gnueabi;               fi
   - if [ "$TARGET" = "Linux-X86" ];     then sudo apt-get install -y g++-4.8-multilib;                    fi
   - if [ "$TARGET" = "Linux-X86_64" ];  then sudo apt-get install -y g++-4.8;                             fi
-  # Running LLGS tests requires a recent enough cmake (for the LLVM cmake
-  # step), and an install of lldb (for the tests to be able to use the lldb
-  # python library without us building it).
-  - if [ "$LLGS_TESTS" = "1" ];         then sudo apt-get install -y cmake swig lldb-3.3;                 fi
+  # Running LLGS tests requires an install of lldb (for the tests to be able to
+  # use the lldb python library without us building it).
+  - if [ "$LLGS_TESTS" = "1" ];         then sudo apt-get install -y swig lldb-3.3;                       fi
+  - sudo apt-get install -y cmake
 
 before_script:
   - mkdir -p build && cd build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,3 +206,6 @@ CHECK_INCLUDE_FILE(sys/personality.h HAVE_SYS_PERSONALITY_H)
 if (HAVE_SYS_PERSONALITY_H)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DHAVE_SYS_PERSONALITY_H")
 endif ()
+
+include(FindThreads)
+target_link_libraries(ds2 ${CMAKE_THREAD_LIBS_INIT})


### PR DESCRIPTION
ds2 needs to link with a thread library to run correctly
with llgs test.
