### PR TITLE
Lower checksum failure logs from Warning to Info.

### DIFF
--- a/Sources/GDBRemote/PacketProcessor.cpp
+++ b/Sources/GDBRemote/PacketProcessor.cpp
@@ -37,7 +37,7 @@ bool PacketProcessor::validate() {
   uint8_t our_csum = Checksum(_buffer);
 
   if (csum != our_csum)
-    DS2LOG(Protocol, Warning,
+    DS2LOG(Protocol, Info,
            "received packet %s with invalid checksum, should be %.2x, is %.2x",
            _buffer.c_str(), our_csum, csum);
 


### PR DESCRIPTION
LLGS test suite always sends packets with 0 checksum. We end up printing
a ton of useless warnings in this case.