### PR TITLE
Windows continue and single step.

### DIFF
--- a/Headers/DebugServer2/Host/Linux/Platform.h
+++ b/Headers/DebugServer2/Host/Linux/Platform.h
@@ -11,6 +11,10 @@
 #ifndef __DebugServer2_Host_Linux_Platform_h
 #define __DebugServer2_Host_Linux_Platform_h
 
+#ifndef __DebugServer2_Host_Platform_h
+#error "You shall not include this file directly."
+#endif
+
 #include "DebugServer2/Host/POSIX/Platform.h"
 
 #include <functional>

--- a/Headers/DebugServer2/Host/POSIX/PTrace.h
+++ b/Headers/DebugServer2/Host/POSIX/PTrace.h
@@ -77,10 +77,6 @@ public:
   virtual ErrorCode execute(ProcessThreadId const &ptid,
                             ProcessInfo const &pinfo, void const *code,
                             size_t length, uint64_t &result);
-
-protected:
-  static ErrorCode TranslateErrno(int error);
-  static ErrorCode TranslateErrno();
 };
 }
 }

--- a/Headers/DebugServer2/Host/POSIX/Platform.h
+++ b/Headers/DebugServer2/Host/POSIX/Platform.h
@@ -58,6 +58,10 @@ public:
 public:
   static ProcessId GetCurrentProcessId();
   static bool GetCurrentEnvironment(EnvironmentBlock &env);
+
+public:
+  static ErrorCode TranslateError(int error);
+  static ErrorCode TranslateError();
 };
 }
 }

--- a/Headers/DebugServer2/Host/Windows/Platform.h
+++ b/Headers/DebugServer2/Host/Windows/Platform.h
@@ -73,6 +73,10 @@ public:
   static bool GetCurrentEnvironment(EnvironmentBlock &env);
 
 public:
+  static ErrorCode TranslateError(DWORD error);
+  static ErrorCode TranslateError();
+
+public:
   static std::wstring NarrowToWideString(std::string const &s);
   static std::string WideToNarrowString(std::wstring const &s);
 };

--- a/Headers/DebugServer2/Target/Linux/Thread.h
+++ b/Headers/DebugServer2/Target/Linux/Thread.h
@@ -45,9 +45,6 @@ protected:
   virtual ErrorCode updateTrapInfo(int waitStatus);
   virtual void updateState();
 
-private:
-  void updateState(bool force);
-
 protected:
   virtual ErrorCode prepareSoftwareSingleStep(Address const &address);
 };

--- a/Headers/DebugServer2/Target/ThreadBase.h
+++ b/Headers/DebugServer2/Target/ThreadBase.h
@@ -65,7 +65,7 @@ public:
 
 protected:
   friend class ProcessBase;
-  virtual void updateState();
+  virtual void updateState() = 0;
 
 protected:
   virtual ErrorCode prepareSoftwareSingleStep(Address const &address);

--- a/Headers/DebugServer2/Target/Windows/Process.h
+++ b/Headers/DebugServer2/Target/Windows/Process.h
@@ -53,13 +53,9 @@ public:
 
 public:
   ErrorCode readMemory(Address const &address, void *data, size_t length,
-                       size_t *nread = nullptr) {
-    return kErrorUnsupported;
-  }
+                       size_t *nread = nullptr);
   ErrorCode writeMemory(Address const &address, void const *data, size_t length,
-                        size_t *nwritten = nullptr) {
-    return kErrorUnsupported;
-  }
+                        size_t *nwritten = nullptr);
 
 public:
   virtual ErrorCode getMemoryRegionInfo(Address const &address,

--- a/Headers/DebugServer2/Target/Windows/Thread.h
+++ b/Headers/DebugServer2/Target/Windows/Thread.h
@@ -35,9 +35,7 @@ public:
   virtual ErrorCode suspend() { return kErrorUnsupported; }
 
 public:
-  virtual ErrorCode step(int signal = 0, Address const &address = Address()) {
-    return kErrorUnsupported;
-  }
+  virtual ErrorCode step(int signal = 0, Address const &address = Address());
   virtual ErrorCode resume(int signal = 0, Address const &address = Address());
 
 public:
@@ -47,9 +45,6 @@ public:
 protected:
   virtual void updateState();
   virtual void updateState(DEBUG_EVENT const &de);
-
-protected:
-  virtual ErrorCode updateTrapInfo() { return kErrorUnsupported; }
 };
 }
 }

--- a/Headers/DebugServer2/Target/Windows/Thread.h
+++ b/Headers/DebugServer2/Target/Windows/Thread.h
@@ -45,6 +45,9 @@ public:
   virtual ErrorCode writeCPUState(Architecture::CPUState const &state);
 
 protected:
+  virtual void updateState() {}
+
+protected:
   virtual ErrorCode updateTrapInfo() { return kErrorUnsupported; }
 };
 }

--- a/Headers/DebugServer2/Target/Windows/Thread.h
+++ b/Headers/DebugServer2/Target/Windows/Thread.h
@@ -45,7 +45,8 @@ public:
   virtual ErrorCode writeCPUState(Architecture::CPUState const &state);
 
 protected:
-  virtual void updateState() {}
+  virtual void updateState();
+  virtual void updateState(DEBUG_EVENT const &de);
 
 protected:
   virtual ErrorCode updateTrapInfo() { return kErrorUnsupported; }

--- a/Headers/DebugServer2/Types.h
+++ b/Headers/DebugServer2/Types.h
@@ -104,9 +104,6 @@ struct TrapInfo {
     kReasonThreadExit,
   };
 
-  ProcessId pid;
-  ThreadId tid;
-
   Event event;
   Reason reason;
   uint32_t core;
@@ -121,9 +118,6 @@ struct TrapInfo {
   TrapInfo() { clear(); }
 
   inline void clear() {
-    pid = kAnyProcessId;
-    tid = kAnyThreadId;
-
     core = 0;
 
     event = kEventNone;

--- a/Headers/DebugServer2/Types.h
+++ b/Headers/DebugServer2/Types.h
@@ -108,7 +108,9 @@ struct TrapInfo {
   Reason reason;
   uint32_t core;
   int status;
+#if !defined(_WIN32)
   int signal;
+#endif
 
   struct {
     uint32_t type;
@@ -123,7 +125,9 @@ struct TrapInfo {
     event = kEventNone;
     reason = kReasonNone;
     status = 0;
+#if !defined(_WIN32)
     signal = 0;
+#endif
 
     exception.type = 0;
     exception.data[0] = 0;

--- a/Headers/DebugServer2/Utils/Log.h
+++ b/Headers/DebugServer2/Utils/Log.h
@@ -22,21 +22,6 @@
 namespace ds2 {
 
 //
-// Log Categories
-//
-enum {
-  kLogMain,
-  kLogDebugSession,
-  kLogPlatformSession,
-  kLogSlaveSession,
-  kLogBPManager,
-  kLogProtocol,
-  kLogRemote,
-  kLogArchitecture,
-  kLogTarget
-};
-
-//
 // Log Level
 //
 enum {
@@ -44,33 +29,31 @@ enum {
   kLogLevelInfo,
   kLogLevelWarning,
   kLogLevelError,
-  kLogLevelFatal
+  kLogLevelFatal,
 };
 
 uint32_t GetLogLevel();
 void SetLogLevel(uint32_t level);
-void SetLogMask(uint64_t mask);
 void SetLogColorsEnabled(bool enabled);
 void SetLogOutputStream(FILE *stream);
 
-void Log(int category, int level, char const *classname, char const *funcname,
-         char const *format, ...) DS2_ATTRIBUTE_PRINTF(5, 6);
+void Log(int level, char const *classname, char const *funcname,
+         char const *format, ...) DS2_ATTRIBUTE_PRINTF(4, 5);
 
 #ifdef __DS2_LOG_CLASS_NAME__
-#define DS2LOG(CAT, LVL, ...)                                                  \
-  ds2::Log(ds2::kLog##CAT, ds2::kLogLevel##LVL, __DS2_LOG_CLASS_NAME__,        \
-           __FUNCTION__, __VA_ARGS__)
-#else
-#define DS2LOG(CAT, LVL, ...)                                                  \
-  ds2::Log(ds2::kLog##CAT, ds2::kLogLevel##LVL, nullptr, __FUNCTION__,         \
+#define DS2LOG(LVL, ...)                                                       \
+  ds2::Log(ds2::kLogLevel##LVL, __DS2_LOG_CLASS_NAME__, __FUNCTION__,          \
            __VA_ARGS__)
+#else
+#define DS2LOG(LVL, ...)                                                       \
+  ds2::Log(ds2::kLogLevel##LVL, nullptr, __FUNCTION__, __VA_ARGS__)
 #endif
 
 #if !defined(NDEBUG)
 #define DS2ASSERT(COND)                                                        \
   do {                                                                         \
     if (!(COND)) {                                                             \
-      DS2LOG(Main, Error, "assertion `%s' failed at %s:%d", #COND, __FILE__,   \
+      DS2LOG(Fatal, "assertion `%s' failed at %s:%d", #COND, __FILE__,         \
              __LINE__);                                                        \
       abort();                                                                 \
     }                                                                          \

--- a/Headers/DebugServer2/Utils/Log.h
+++ b/Headers/DebugServer2/Utils/Log.h
@@ -61,6 +61,15 @@ void Log(int level, char const *classname, char const *funcname,
 #else
 #define DS2ASSERT(COND) (void)0
 #endif
+
+// DS2LOG(Fatal...) already aborts but we add an additional abort() to make it
+// explicit to the compiler that this call doesn't return. This way we can
+// avoid unnecessary returns in users of DS2BUG.
+#define DS2BUG(...)                                                            \
+  do {                                                                         \
+    DS2LOG(Fatal, __VA_ARGS__);                                                \
+    abort();                                                                   \
+  } while (0)
 }
 
 #endif // !__DebugServer2_Utils_Log_h

--- a/Main/main.cpp
+++ b/Main/main.cpp
@@ -52,17 +52,17 @@ static void PlatformMain(int argc, char **argv, int port) {
   Socket *server = new Socket;
 
   if (!server->create()) {
-    DS2LOG(Main, Error, "cannot create server socket on port %d: %s", port,
+    DS2LOG(Error, "cannot create server socket on port %d: %s", port,
            server->error().c_str());
     exit(EXIT_FAILURE);
   }
 
   if (!server->listen(port)) {
-    DS2LOG(Main, Error, "error: failed to listen: %s", server->error().c_str());
+    DS2LOG(Error, "error: failed to listen: %s", server->error().c_str());
     exit(EXIT_FAILURE);
   }
 
-  DS2LOG(Main, Info, "listening on port %d", port);
+  DS2LOG(Info, "listening on port %d", port);
 
   PlatformSessionImpl impl;
 
@@ -93,14 +93,14 @@ static void RunDebugServer(Socket *server, SessionDelegate *impl) {
   session.setDelegate(impl);
   session.create(qchannel);
 
-  DS2LOG(Main, Debug, "DEBUG SERVER STARTED");
+  DS2LOG(Debug, "DEBUG SERVER STARTED");
 
   thread.start();
 
   while (session.receive(/*cooked=*/true))
     ;
 
-  DS2LOG(Main, Debug, "DEBUG SERVER KILLED");
+  DS2LOG(Debug, "DEBUG SERVER KILLED");
 }
 
 static void DebugMain(ds2::StringCollection const &args,
@@ -109,23 +109,23 @@ static void DebugMain(ds2::StringCollection const &args,
   Socket *server = new Socket;
 
   if (!server->create()) {
-    DS2LOG(Main, Error, "cannot create server socket on port %d: %s", port,
+    DS2LOG(Error, "cannot create server socket on port %d: %s", port,
            server->error().c_str());
     exit(EXIT_FAILURE);
   }
 
   if (!server->listen(port)) {
-    DS2LOG(Main, Error, "failed to listen: %s", server->error().c_str());
+    DS2LOG(Error, "failed to listen: %s", server->error().c_str());
     exit(EXIT_FAILURE);
   }
 
-  DS2LOG(Main, Info, "listening on port %d", server->port());
+  DS2LOG(Info, "listening on port %d", server->port());
 
   if (!namedPipePath.empty()) {
     std::string portStr = ds2::ToString(server->port());
     FILE *namedPipe = fopen(namedPipePath.c_str(), "a");
     if (namedPipe == nullptr) {
-      DS2LOG(Main, Error, "unable to open %s: %s", namedPipePath.c_str(),
+      DS2LOG(Error, "unable to open %s: %s", namedPipePath.c_str(),
              strerror(errno));
     } else {
       // Write the null terminator to the file. This follows the llgs behavior.
@@ -191,7 +191,7 @@ static void SlaveMain(int argc, char **argv) {
     //
     fprintf(stdout, "%u %d\n", port, pid);
 
-    DS2LOG(Main, Info, "listening on port %u pid %d", port, pid);
+    DS2LOG(Info, "listening on port %u pid %d", port, pid);
   }
 
   exit(EXIT_SUCCESS);
@@ -244,7 +244,6 @@ int main(int argc, char **argv) {
   ds2::SetLogColorsEnabled(isatty(fileno(stderr)));
 #endif
   ds2::SetLogLevel(ds2::kLogLevelWarning);
-  ds2::SetLogMask(~0U);
 
   enum RunMode {
     kRunModeNormal,
@@ -306,7 +305,7 @@ int main(int argc, char **argv) {
   if (!opts.getString("log-output").empty()) {
     FILE *stream = fopen(opts.getString("log-output").c_str(), "a");
     if (stream == nullptr) {
-      DS2LOG(Main, Error, "unable to open %s for writing: %s",
+      DS2LOG(Error, "unable to open %s for writing: %s",
              opts.getString("log-output").c_str(), strerror(errno));
     } else {
 #if !defined(_WIN32)
@@ -413,7 +412,7 @@ int main(int argc, char **argv) {
       char const *arg = e.c_str();
       char const *equal = strchr(arg, '=');
       if (equal == nullptr || equal == arg)
-        DS2LOG(Main, Fatal, "invalid environment value: %s", arg);
+        DS2LOG(Fatal, "invalid environment value: %s", arg);
       env[std::string(arg, equal)] = equal + 1;
     }
 

--- a/Sources/Architecture/ARM/SoftwareBreakpointManager.cpp
+++ b/Sources/Architecture/ARM/SoftwareBreakpointManager.cpp
@@ -163,7 +163,7 @@ void SoftwareBreakpointManager::getOpcode(uint32_t type,
     break;
 #endif
   default:
-    DS2LOG(BPManager, Error, "invalid breakpoint type %d", type);
+    DS2LOG(Error, "invalid breakpoint type %d", type);
     DS2ASSERT(0 && "invalid breakpoint type");
     break;
   }
@@ -178,20 +178,19 @@ void SoftwareBreakpointManager::enableLocation(Site const &site) {
   old.resize(opcode.size());
   error = _process->readMemory(site.address, &old[0], old.size());
   if (error != kSuccess) {
-    DS2LOG(BPManager, Error, "cannot enable breakpoint at %#lx",
+    DS2LOG(Error, "cannot enable breakpoint at %#lx",
            (unsigned long)site.address.value());
     return;
   }
 
   error = _process->writeMemory(site.address, &opcode[0], opcode.size());
   if (error != kSuccess) {
-    DS2LOG(BPManager, Error, "cannot enable breakpoint at %#lx",
+    DS2LOG(Error, "cannot enable breakpoint at %#lx",
            (unsigned long)site.address.value());
     return;
   }
 
-  DS2LOG(BPManager, Info,
-         "set breakpoint instruction %#lx at %#lx (saved insn %#lx)",
+  DS2LOG(Info, "set breakpoint instruction %#lx at %#lx (saved insn %#lx)",
          (unsigned long)(site.size == 2 ? *(uint16_t *)&opcode[0]
                                         : *(uint32_t *)&opcode[0]),
          (unsigned long)site.address.value(),
@@ -207,12 +206,12 @@ void SoftwareBreakpointManager::disableLocation(Site const &site) {
 
   error = _process->writeMemory(site.address, &old[0], old.size());
   if (error != kSuccess) {
-    DS2LOG(BPManager, Error, "cannot restore instruction at %#lx",
+    DS2LOG(Error, "cannot restore instruction at %#lx",
            (unsigned long)site.address.value());
     return;
   }
 
-  DS2LOG(BPManager, Info, "reset instruction %#lx at %#lx",
+  DS2LOG(Info, "reset instruction %#lx at %#lx",
          (unsigned long)(site.size == 2 ? *(uint16_t *)&old[0]
                                         : *(uint32_t *)&old[0]),
          (unsigned long)site.address.value());

--- a/Sources/Architecture/X86/SoftwareBreakpointManager.cpp
+++ b/Sources/Architecture/X86/SoftwareBreakpointManager.cpp
@@ -77,21 +77,20 @@ void SoftwareBreakpointManager::enableLocation(Site const &site) {
 
   error = _process->readMemory(site.address, &old, sizeof(old));
   if (error != kSuccess) {
-    DS2LOG(BPManager, Error, "cannot enable breakpoint at %#lx",
+    DS2LOG(Error, "cannot enable breakpoint at %#lx",
            (unsigned long)site.address.value());
     return;
   }
 
   error = _process->writeMemory(site.address, &opcode, sizeof(opcode));
   if (error != kSuccess) {
-    DS2LOG(BPManager, Error, "cannot enable breakpoint at %#lx",
+    DS2LOG(Error, "cannot enable breakpoint at %#lx",
            (unsigned long)site.address.value());
     return;
   }
 
-  DS2LOG(BPManager, Info,
-         "set breakpoint instruction %#x at %#lx (saved insn %#x)", opcode,
-         (unsigned long)site.address.value(), old);
+  DS2LOG(Info, "set breakpoint instruction %#x at %#lx (saved insn %#x)",
+         opcode, (unsigned long)site.address.value(), old);
 
   _insns[site.address] = old;
 }
@@ -102,12 +101,12 @@ void SoftwareBreakpointManager::disableLocation(Site const &site) {
 
   error = _process->writeMemory(site.address, &old, sizeof(old));
   if (error != kSuccess) {
-    DS2LOG(BPManager, Error, "cannot restore instruction at %#lx",
+    DS2LOG(Error, "cannot restore instruction at %#lx",
            (unsigned long)site.address.value());
     return;
   }
 
-  DS2LOG(BPManager, Info, "reset instruction %#x at %#lx", old,
+  DS2LOG(Info, "reset instruction %#x at %#lx", old,
          (unsigned long)site.address.value());
 
   _insns.erase(site.address);

--- a/Sources/BreakpointManager.cpp
+++ b/Sources/BreakpointManager.cpp
@@ -114,7 +114,7 @@ void BreakpointManager::enable() {
   // enabling the breakpoint manager.
   //
   if (_enabled)
-    DS2LOG(BPManager, Warning, "double-enabling breakpoints");
+    DS2LOG(Warning, "double-enabling breakpoints");
   _enabled = true;
 
   enumerate([this](Site const &site) { enableLocation(site); });
@@ -122,7 +122,7 @@ void BreakpointManager::enable() {
 
 void BreakpointManager::disable() {
   if (!_enabled)
-    DS2LOG(BPManager, Warning, "double-disabling breakpoints");
+    DS2LOG(Warning, "double-disabling breakpoints");
   _enabled = false;
 
   enumerate([this](Site const &site) { disableLocation(site); });

--- a/Sources/GDBRemote/DebugSessionImpl.cpp
+++ b/Sources/GDBRemote/DebugSessionImpl.cpp
@@ -169,8 +169,8 @@ ErrorCode DebugSessionImpl::queryStopCode(Session &session,
 
   Architecture::CPUState state;
 
-  stop.ptid.pid = trap.pid;
-  stop.ptid.tid = trap.tid;
+  stop.ptid.pid = thread->process()->pid();
+  stop.ptid.tid = thread->tid();
   stop.core = trap.core;
   stop.reason = StopCode::kSignalStop;
   switch (trap.event) {

--- a/Sources/GDBRemote/DebugSessionImpl.cpp
+++ b/Sources/GDBRemote/DebugSessionImpl.cpp
@@ -185,18 +185,24 @@ ErrorCode DebugSessionImpl::queryStopCode(Session &session,
   case TrapInfo::kEventKill:
   case TrapInfo::kEventCoreDump:
     stop.event = StopCode::kSignalExit;
+#if !defined(_WIN32)
     stop.signal = trap.signal;
+#endif
     readRegisters = false;
     break;
   case TrapInfo::kEventTrap:
     stop.event = StopCode::kSignal;
     stop.reason = StopCode::kBreakpoint;
+#if !defined(_WIN32)
     stop.signal = trap.signal;
+#endif
     break;
   case TrapInfo::kEventStop:
     stop.event = StopCode::kSignal;
     stop.reason = StopCode::kSignalStop;
+#if !defined(_WIN32)
     stop.signal = trap.signal;
+#endif
     break;
   }
 
@@ -786,7 +792,7 @@ DebugSessionImpl::onResume(Session &session,
                action.action == kResumeActionSingleStepWithSignal) {
       error = thread->step(action.signal, action.address);
       if (error != kSuccess) {
-        DS2LOG(DebugSession, Warning, "cannot resume pid %d tid %d, error=%d",
+        DS2LOG(DebugSession, Warning, "cannot step pid %d tid %d, error=%d",
                _process->pid(), thread->tid(), error);
         continue;
       }
@@ -820,7 +826,7 @@ DebugSessionImpl::onResume(Session &session,
       if (excluded.find(thread) == excluded.end()) {
         error = thread->step(globalAction.signal, globalAction.address);
         if (error != kSuccess) {
-          DS2LOG(DebugSession, Warning, "cannot resume pid %d tid %d, error=%d",
+          DS2LOG(DebugSession, Warning, "cannot step pid %d tid %d, error=%d",
                  _process->pid(), thread->tid(), error);
         }
       }

--- a/Sources/GDBRemote/PacketProcessor.cpp
+++ b/Sources/GDBRemote/PacketProcessor.cpp
@@ -37,7 +37,7 @@ bool PacketProcessor::validate() {
   uint8_t our_csum = Checksum(_buffer);
 
   if (csum != our_csum)
-    DS2LOG(Protocol, Info,
+    DS2LOG(Info,
            "received packet %s with invalid checksum, should be %.2x, is %.2x",
            _buffer.c_str(), our_csum, csum);
 

--- a/Sources/GDBRemote/PlatformSessionImpl.cpp
+++ b/Sources/GDBRemote/PlatformSessionImpl.cpp
@@ -55,8 +55,7 @@ ErrorCode PlatformSessionImpl::onQueryProcessInfo(Session &, ProcessId pid,
 ErrorCode PlatformSessionImpl::onExecuteProgram(
     Session &, std::string const &command, uint32_t timeout,
     std::string const &workingDirectory, ProgramResult &result) {
-  DS2LOG(PlatformSession, Debug, "command='%s' timeout=%u", command.c_str(),
-         timeout);
+  DS2LOG(Debug, "command='%s' timeout=%u", command.c_str(), timeout);
 
   ProcessSpawner ps;
 
@@ -199,7 +198,7 @@ ErrorCode PlatformSessionImpl::onSetWorkingDirectory(Session &,
 
 ErrorCode PlatformSessionImpl::onSetStdFile(Session &, int fileno,
                                             std::string const &path) {
-  DS2LOG(PlatformSession, Debug, "stdfile[%d] = %s", fileno, path.c_str());
+  DS2LOG(Debug, "stdfile[%d] = %s", fileno, path.c_str());
 
   if (fileno < 0 || fileno > 2)
     return kErrorInvalidArgument;
@@ -235,7 +234,7 @@ PlatformSessionImpl::onSetProgramArguments(Session &,
                                            StringCollection const &args) {
   _arguments = args;
   for (auto const &arg : _arguments) {
-    DS2LOG(PlatformSession, Debug, "arg=%s", arg.c_str());
+    DS2LOG(Debug, "arg=%s", arg.c_str());
   }
   return kSuccess;
 }

--- a/Sources/GDBRemote/PlatformSessionImpl.cpp
+++ b/Sources/GDBRemote/PlatformSessionImpl.cpp
@@ -86,7 +86,7 @@ ErrorCode PlatformSessionImpl::onFileOpen(Session &, std::string const &path,
                                           uint32_t flags, uint32_t mode,
                                           int &fd) {
   if ((fd = Platform::OpenFile(path, flags, mode)) < 0)
-    return kErrorUnknown;
+    return Platform::TranslateError();
   else
     return kSuccess;
 }
@@ -98,7 +98,7 @@ ErrorCode PlatformSessionImpl::onFileClose(Session &session, int fd) {
   // arbitrary file descriptors.
   //
   if (!Platform::CloseFile(fd))
-    return kErrorUnknown;
+    return Platform::TranslateError();
   else
     return kSuccess;
 }

--- a/Sources/GDBRemote/ProtocolInterpreter.cpp
+++ b/Sources/GDBRemote/ProtocolInterpreter.cpp
@@ -43,7 +43,7 @@ static std::string EscapeForTerm(std::string const &s) {
 ProtocolInterpreter::ProtocolInterpreter() : _session(nullptr) {}
 
 void ProtocolInterpreter::onPacketData(std::string const &data, bool valid) {
-  DS2LOG(Remote, Debug, "getpkt(\"%s\")", EscapeForTerm(&data[0]).c_str());
+  DS2LOG(Debug, "getpkt(\"%s\")", EscapeForTerm(&data[0]).c_str());
 
   if (_session == nullptr)
     return;
@@ -138,7 +138,7 @@ void ProtocolInterpreter::onPacketData(std::string const &data, bool valid) {
 }
 
 void ProtocolInterpreter::onInvalidData(std::string const &data) {
-  DS2LOG(Protocol, Warning, "received invalid data: '%s'", data.c_str());
+  DS2LOG(Warning, "received invalid data: '%s'", data.c_str());
 
   if (_session == nullptr)
     return;
@@ -151,8 +151,7 @@ void ProtocolInterpreter::onCommand(std::string const &command,
   size_t commandLength;
   Handler const *handler = findHandler(command, commandLength);
   if (handler == nullptr) {
-    DS2LOG(Protocol, Debug, "handler for command '%s' unknown",
-           command.c_str());
+    DS2LOG(Debug, "handler for command '%s' unknown", command.c_str());
 
     //
     // The handler couldn't be found, send a NAK.
@@ -173,12 +172,11 @@ void ProtocolInterpreter::onCommand(std::string const &command,
 
   if (extra.find_first_of("*}") != std::string::npos) {
     extra = Uncompress(extra);
-    DS2LOG(Protocol, Debug, "args='%.*s'", static_cast<int>(extra.length()),
-           &extra[0]);
+    DS2LOG(Debug, "args='%.*s'", static_cast<int>(extra.length()), &extra[0]);
   }
 
 #if 0
-    DS2LOG(Protocol, Debug, "command='%s' arguments='%s'\n",
+    DS2LOG(Debug, "command='%s' arguments='%s'\n",
             command.substr(0, commandLength).c_str(),
             extra.c_str());
 #endif

--- a/Sources/GDBRemote/Session.cpp
+++ b/Sources/GDBRemote/Session.cpp
@@ -729,8 +729,8 @@ void Session::Handle_H(ProtocolInterpreter::Handler const &,
   _ptids[command] = ptid;
   sendOK();
 
-  DS2LOG(DebugSession, Debug, "setting command '%c' to pid %d tid %d", command,
-         ptid.pid, ptid.tid);
+  DS2LOG(Debug, "setting command '%c' to pid %d tid %d", command, ptid.pid,
+         ptid.tid);
 }
 
 //
@@ -1358,7 +1358,7 @@ void Session::Handle_QLaunchArch(ProtocolInterpreter::Handler const &,
 void Session::Handle_QListThreadsInStopReply(
     ProtocolInterpreter::Handler const &, std::string const &) {
   if (_compatMode != kCompatibilityModeLLDB) {
-    DS2LOG(DebugSession, Debug, "entering LLDB compatibility mode");
+    DS2LOG(Debug, "entering LLDB compatibility mode");
     _compatMode = kCompatibilityModeLLDB;
   }
 
@@ -1438,7 +1438,7 @@ void Session::Handle_QThreadSuffixSupported(
     ProtocolInterpreter::Handler const &, std::string const &) {
   // We always support them.
   if (_compatMode != kCompatibilityModeLLDB) {
-    DS2LOG(DebugSession, Debug, "entering LLDB compatibility mode");
+    DS2LOG(Debug, "entering LLDB compatibility mode");
     _compatMode = kCompatibilityModeLLDB;
   }
 
@@ -2132,8 +2132,7 @@ void Session::Handle_qSupported(ProtocolInterpreter::Handler const &,
 
     Feature const &feature = remoteFeatures.back();
     if (feature.name == "multiprocess" && feature.flag == Feature::kSupported) {
-      DS2LOG(DebugSession, Debug,
-             "entering GDB multiprocess compatibility mode");
+      DS2LOG(Debug, "entering GDB multiprocess compatibility mode");
       _compatMode = kCompatibilityModeGDBMultiprocess;
     }
   });

--- a/Sources/GDBRemote/SessionBase.cpp
+++ b/Sources/GDBRemote/SessionBase.cpp
@@ -97,7 +97,7 @@ bool SessionBase::send(std::string const &data, bool escaped) {
      << (unsigned)csum;
 
   std::string final_data = ss.str();
-  DS2LOG(Remote, Debug, "putpkt(\"%s\", %u)", final_data.c_str(),
+  DS2LOG(Debug, "putpkt(\"%s\", %u)", final_data.c_str(),
          (unsigned)final_data.length());
 
   return _channel->send(final_data);

--- a/Sources/GDBRemote/Structures.cpp
+++ b/Sources/GDBRemote/Structures.cpp
@@ -314,7 +314,22 @@ std::string StopCode::encode(CompatibilityMode mode) const {
   if (event == kCleanExit) {
     ss << HEX(2) << (status & 0xff) << DEC;
   } else {
+#if !defined(_WIN32)
     ss << HEX(2) << (reason != kNone ? (signal & 0xff) : 0) << DEC;
+#else
+    // Windows doesn't have a notion of signals but the gdb protocol still
+    // needs some sort of emulation for these.
+    ss << HEX(2);
+    switch (reason) {
+    case kBreakpoint:
+      ss << 5;
+      break;
+    default:
+      ss << 0;
+      break;
+    }
+    ss << DEC;
+#endif
   }
 
   //

--- a/Sources/GDBRemote/Structures.cpp
+++ b/Sources/GDBRemote/Structures.cpp
@@ -229,7 +229,7 @@ std::string StopCode::encodeInfo(CompatibilityMode mode) const {
       case kAddressWatchpoint:
       case kLibraryLoad:
       case kReplayLog:
-        DS2LOG(Protocol, Warning, "stop reason not implemented: %d", reason);
+        DS2LOG(Warning, "stop reason not implemented: %d", reason);
       }
     }
 

--- a/Sources/Host/Linux/ARM/PTraceARM.cpp
+++ b/Sources/Host/Linux/ARM/PTraceARM.cpp
@@ -8,8 +8,9 @@
 // PATENTS file in the same directory.
 //
 
-#include "DebugServer2/Host/Linux/PTrace.h"
 #include "DebugServer2/Host/Linux/ExtraWrappers.h"
+#include "DebugServer2/Host/Linux/PTrace.h"
+#include "DebugServer2/Host/Platform.h"
 
 #define super ds2::Host::POSIX::PTrace
 
@@ -89,7 +90,7 @@ ErrorCode PTrace::readCPUState(ProcessThreadId const &ptid, ProcessInfo const &,
   //
   struct pt_regs gprs;
   if (wrapPtrace(PTRACE_GETREGS, pid, nullptr, &gprs) < 0)
-    return TranslateErrno();
+    return Platform::TranslateError();
 
   //
   // The layout is identical.
@@ -101,7 +102,7 @@ ErrorCode PTrace::readCPUState(ProcessThreadId const &ptid, ProcessInfo const &,
                 "sizeof(ARM::CPUState.vfp) does not match ARM_VFPREGS_SIZE");
 
   if (wrapPtrace(PTRACE_GETVFPREGS, pid, nullptr, &state.vfp) < 0)
-    return TranslateErrno();
+    return Platform::TranslateError();
 #endif
 
   //
@@ -168,14 +169,14 @@ ErrorCode PTrace::writeCPUState(ProcessThreadId const &ptid,
   gprs.ARM_ORIG_r0 = 0;
 
   if (wrapPtrace(PTRACE_SETREGS, pid, nullptr, &gprs) < 0)
-    return TranslateErrno();
+    return Platform::TranslateError();
 
 #if (__ARM_ARCH >= 7)
   static_assert(sizeof(state.vfp) == ARM_VFPREGS_SIZE,
                 "sizeof(ARM::CPUState.vfp) does not match ARM_VFPREGS_SIZE");
 
   if (wrapPtrace(PTRACE_SETVFPREGS, pid, nullptr, &state.vfp) < 0)
-    return TranslateErrno();
+    return Platform::TranslateError();
 #endif
 
   //

--- a/Sources/Host/Linux/ARM64/PTraceARM64.cpp
+++ b/Sources/Host/Linux/ARM64/PTraceARM64.cpp
@@ -8,8 +8,9 @@
 // PATENTS file in the same directory.
 //
 
-#include "DebugServer2/Host/Linux/PTrace.h"
 #include "DebugServer2/Host/Linux/ExtraWrappers.h"
+#include "DebugServer2/Host/Linux/PTrace.h"
+#include "DebugServer2/Host/Platform.h"
 
 #define super ds2::Host::POSIX::PTrace
 

--- a/Sources/Host/Linux/PTrace.cpp
+++ b/Sources/Host/Linux/PTrace.cpp
@@ -10,9 +10,10 @@
 
 #define __DS2_LOG_CLASS_NAME__ "PTrace"
 
-#include "DebugServer2/Host/Linux/PTrace.h"
 #include "DebugServer2/Host/Linux/ExtraWrappers.h"
+#include "DebugServer2/Host/Linux/PTrace.h"
 #include "DebugServer2/Host/POSIX/AsyncProcessWaiter.h"
+#include "DebugServer2/Host/Platform.h"
 #include "DebugServer2/Utils/Log.h"
 
 #include <cerrno>
@@ -68,7 +69,7 @@ ErrorCode PTrace::traceMe(bool disableASLR) {
   }
 
   if (wrapPtrace(PTRACE_TRACEME, 0, nullptr, nullptr) < 0)
-    return TranslateErrno();
+    return Platform::TranslateError();
 
   return kSuccess;
 }
@@ -86,7 +87,7 @@ ErrorCode PTrace::traceThat(ProcessId pid) {
     DS2LOG(Main, Warning,
            "unable to set PTRACE_O_TRACECLONE on pid %d, error=%s", pid,
            strerror(errno));
-    return TranslateErrno();
+    return Platform::TranslateError();
   }
 
   return kSuccess;
@@ -97,7 +98,7 @@ ErrorCode PTrace::attach(ProcessId pid) {
     return kErrorProcessNotFound;
 
   if (wrapPtrace(PTRACE_ATTACH, pid, nullptr, nullptr) < 0)
-    return TranslateErrno();
+    return Platform::TranslateError();
 
   return kSuccess;
 }
@@ -109,7 +110,7 @@ ErrorCode PTrace::detach(ProcessId pid) {
   DS2LOG(Main, Debug, "detaching from pid %llu", (unsigned long long)pid);
 
   if (wrapPtrace(PTRACE_DETACH, pid, nullptr, nullptr) < 0)
-    return TranslateErrno();
+    return Platform::TranslateError();
 
   return kSuccess;
 }
@@ -130,7 +131,7 @@ ErrorCode PTrace::kill(ProcessThreadId const &ptid, int signal) {
   }
 
   if (rc < 0)
-    return TranslateErrno();
+    return Platform::TranslateError();
 
   return kSuccess;
 }
@@ -184,7 +185,7 @@ ErrorCode PTrace::readMemory(ProcessThreadId const &ptid,
   }
 
   if (errno != 0)
-    return TranslateErrno();
+    return Platform::TranslateError();
 
   if (count != nullptr) {
     *count = nread;
@@ -243,7 +244,7 @@ ErrorCode PTrace::writeMemory(ProcessThreadId const &ptid,
   }
 
   if (errno != 0)
-    return TranslateErrno();
+    return Platform::TranslateError();
 
   if (count != nullptr) {
     *count = nwritten;
@@ -265,7 +266,7 @@ ErrorCode PTrace::suspend(ProcessThreadId const &ptid) {
   }
 
   if (tkill(pid, SIGSTOP) < 0)
-    return TranslateErrno();
+    return Platform::TranslateError();
 
   return kSuccess;
 }
@@ -307,7 +308,7 @@ ErrorCode PTrace::step(ProcessThreadId const &ptid, ProcessInfo const &pinfo,
   }
 
   if (wrapPtrace(PTRACE_SINGLESTEP, pid, nullptr, signal) < 0)
-    return TranslateErrno();
+    return Platform::TranslateError();
 
   return kSuccess;
 }
@@ -342,7 +343,7 @@ ErrorCode PTrace::resume(ProcessThreadId const &ptid, ProcessInfo const &pinfo,
   }
 
   if (wrapPtrace(PTRACE_CONT, pid, nullptr, signal) < 0)
-    return TranslateErrno();
+    return Platform::TranslateError();
 
   return kSuccess;
 }
@@ -361,7 +362,7 @@ ErrorCode PTrace::getEventPid(ProcessThreadId const &ptid, ProcessId &epid) {
 
   unsigned long value;
   if (wrapPtrace(PTRACE_GETEVENTMSG, pid, nullptr, &value) < 0)
-    return TranslateErrno();
+    return Platform::TranslateError();
 
   epid = value;
   return kSuccess;
@@ -380,7 +381,7 @@ ErrorCode PTrace::getSigInfo(ProcessThreadId const &ptid, siginfo_t &si) {
   }
 
   if (wrapPtrace(PTRACE_GETSIGINFO, pid, nullptr, &si) < 0)
-    return TranslateErrno();
+    return Platform::TranslateError();
 
   return kSuccess;
 }
@@ -391,7 +392,7 @@ ErrorCode PTrace::readRegisterSet(ProcessThreadId const &ptid, int regSetCode,
 
   if (wrapPtrace(PTRACE_GETREGSET, ptid.validTid() ? ptid.tid : ptid.pid,
                  regSetCode, &iov) < 0)
-    return TranslateErrno();
+    return Platform::TranslateError();
 
   // On return, the kernel modifies iov.len to return the number of bytes read.
   // This should be exactly equal to the number of bytes requested.
@@ -406,7 +407,7 @@ ErrorCode PTrace::writeRegisterSet(ProcessThreadId const &ptid, int regSetCode,
 
   if (wrapPtrace(PTRACE_SETREGSET, ptid.validTid() ? ptid.tid : ptid.pid,
                  regSetCode, &iov) < 0)
-    return TranslateErrno();
+    return Platform::TranslateError();
 
   return kSuccess;
 }

--- a/Sources/Host/Linux/PTrace.cpp
+++ b/Sources/Host/Linux/PTrace.cpp
@@ -63,8 +63,7 @@ ErrorCode PTrace::traceMe(bool disableASLR) {
   if (disableASLR) {
     int persona = ::personality(std::numeric_limits<uint32_t>::max());
     if (::personality(persona | ADDR_NO_RANDOMIZE) == -1) {
-      DS2LOG(Main, Warning, "unable to disable ASLR, error=%s",
-             strerror(errno));
+      DS2LOG(Warning, "unable to disable ASLR, error=%s", strerror(errno));
     }
   }
 
@@ -84,9 +83,8 @@ ErrorCode PTrace::traceThat(ProcessId pid) {
   // Trace clone and exit events to track threads.
   //
   if (wrapPtrace(PTRACE_SETOPTIONS, pid, nullptr, traceFlags) < 0) {
-    DS2LOG(Main, Warning,
-           "unable to set PTRACE_O_TRACECLONE on pid %d, error=%s", pid,
-           strerror(errno));
+    DS2LOG(Warning, "unable to set PTRACE_O_TRACECLONE on pid %d, error=%s",
+           pid, strerror(errno));
     return Platform::TranslateError();
   }
 
@@ -107,7 +105,7 @@ ErrorCode PTrace::detach(ProcessId pid) {
   if (pid <= kAnyProcessId)
     return kErrorProcessNotFound;
 
-  DS2LOG(Main, Debug, "detaching from pid %llu", (unsigned long long)pid);
+  DS2LOG(Debug, "detaching from pid %llu", (unsigned long long)pid);
 
   if (wrapPtrace(PTRACE_DETACH, pid, nullptr, nullptr) < 0)
     return Platform::TranslateError();

--- a/Sources/Host/Linux/ProcFS.cpp
+++ b/Sources/Host/Linux/ProcFS.cpp
@@ -163,7 +163,7 @@ FILE *ProcFS::OpenFILE(char const *what, char const *mode) {
   ds2_snprintf(path, PATH_MAX, "/proc/%s", what);
   FILE *res = fopen(path, mode);
   if (res == nullptr)
-    DS2LOG(Target, Error, "can't open %s: %s", path, strerror(errno));
+    DS2LOG(Error, "can't open %s: %s", path, strerror(errno));
   return res;
 }
 
@@ -177,7 +177,7 @@ FILE *ProcFS::OpenFILE(pid_t pid, pid_t tid, char const *what,
   MakePath(path, PATH_MAX, pid, tid, what);
   FILE *res = fopen(path, mode);
   if (res == nullptr)
-    DS2LOG(Target, Error, "can't open %s: %s", path, strerror(errno));
+    DS2LOG(Error, "can't open %s: %s", path, strerror(errno));
   return res;
 }
 

--- a/Sources/Host/Linux/X86/PTraceX86.cpp
+++ b/Sources/Host/Linux/X86/PTraceX86.cpp
@@ -10,6 +10,7 @@
 
 #include "DebugServer2/Host/Linux/PTrace.h"
 #include "DebugServer2/Host/Linux/ExtraWrappers.h"
+#include "DebugServer2/Host/Platform.h"
 
 #define super ds2::Host::POSIX::PTrace
 
@@ -63,7 +64,7 @@ ErrorCode PTrace::readCPUState(ProcessThreadId const &ptid, ProcessInfo const &,
   //
   user_regs_struct gprs;
   if (wrapPtrace(PTRACE_GETREGS, pid, nullptr, &gprs) < 0)
-    return TranslateErrno();
+    return Platform::TranslateError();
 
   state.gp.eax = gprs.eax;
   state.gp.ecx = gprs.ecx;
@@ -181,7 +182,7 @@ ErrorCode PTrace::writeCPUState(ProcessThreadId const &ptid,
   gprs.orig_eax = state.linux_gp.orig_eax;
 
   if (wrapPtrace(PTRACE_SETREGS, pid, nullptr, &gprs) < 0)
-    return TranslateErrno();
+    return Platform::TranslateError();
 
   //
   // Write X87 and SSE state

--- a/Sources/Host/Linux/X86_64/PTraceX86_64.cpp
+++ b/Sources/Host/Linux/X86_64/PTraceX86_64.cpp
@@ -8,8 +8,9 @@
 // PATENTS file in the same directory.
 //
 
-#include "DebugServer2/Host/Linux/PTrace.h"
 #include "DebugServer2/Host/Linux/ExtraWrappers.h"
+#include "DebugServer2/Host/Linux/PTrace.h"
+#include "DebugServer2/Host/Platform.h"
 
 #include <sys/ptrace.h>
 #include <sys/uio.h>
@@ -303,7 +304,7 @@ ErrorCode PTrace::readCPUState(ProcessThreadId const &ptid,
   //
   user_regs_struct gprs;
   if (wrapPtrace(PTRACE_GETREGS, pid, nullptr, &gprs) < 0)
-    return TranslateErrno();
+    return Platform::TranslateError();
 
   if (pinfo.pointerSize == sizeof(uint32_t)) {
     state.is32 = true;
@@ -363,7 +364,7 @@ ErrorCode PTrace::writeCPUState(ProcessThreadId const &ptid,
   }
 
   if (wrapPtrace(PTRACE_SETREGS, pid, nullptr, &gprs) < 0)
-    return TranslateErrno();
+    return Platform::TranslateError();
 
   //
   // Write X87 and SSE state

--- a/Sources/Host/POSIX/PTrace.cpp
+++ b/Sources/Host/POSIX/PTrace.cpp
@@ -105,26 +105,6 @@ ErrorCode PTrace::execute(ProcessThreadId const &ptid, ProcessInfo const &pinfo,
 fail:
   return kill(ptid, SIGKILL); // we can't really do much at this point :(
 }
-
-ErrorCode PTrace::TranslateErrno(int error) {
-  switch (error) {
-  case EBUSY:
-    return ds2::kErrorBusy;
-  case ESRCH:
-    return ds2::kErrorProcessNotFound;
-  case EFAULT:
-    return ds2::kErrorInvalidAddress;
-  case EIO:
-    return ds2::kErrorInvalidAddress;
-  case EPERM:
-    return ds2::kErrorNoPermission;
-  default:
-    break;
-  }
-  return ds2::kErrorInvalidArgument;
-}
-
-ErrorCode PTrace::TranslateErrno() { return TranslateErrno(errno); }
 }
 }
 }

--- a/Sources/Host/POSIX/Platform.cpp
+++ b/Sources/Host/POSIX/Platform.cpp
@@ -195,9 +195,7 @@ ErrorCode Platform::TranslateError(int error) {
   case EPERM:
     return ds2::kErrorNoPermission;
   default:
-    // Make sure we catch unknown error codes during development.
-    DS2ASSERT(false);
-    return kErrorUnknown;
+    DS2BUG("unknown error code: %d", error);
   }
 }
 

--- a/Sources/Host/POSIX/Platform.cpp
+++ b/Sources/Host/POSIX/Platform.cpp
@@ -182,6 +182,26 @@ bool Platform::GetCurrentEnvironment(EnvironmentBlock &env) {
 
   return true;
 }
+
+ErrorCode Platform::TranslateError(int error) {
+  switch (error) {
+  case EBUSY:
+    return ds2::kErrorBusy;
+  case ESRCH:
+    return ds2::kErrorProcessNotFound;
+  case EFAULT:
+  case EIO:
+    return ds2::kErrorInvalidAddress;
+  case EPERM:
+    return ds2::kErrorNoPermission;
+  default:
+    // Make sure we catch unknown error codes during development.
+    DS2ASSERT(false);
+    return kErrorUnknown;
+  }
+}
+
+ErrorCode Platform::TranslateError() { return TranslateError(errno); }
 }
 }
 }

--- a/Sources/Host/POSIX/ProcessSpawner.cpp
+++ b/Sources/Host/POSIX/ProcessSpawner.cpp
@@ -382,7 +382,7 @@ ErrorCode ProcessSpawner::run(std::function<bool()> preExecAction) {
         return kErrorUnknown;
 
       if (::execve(_executablePath.c_str(), &args[0], &environment[0]) < 0) {
-        DS2LOG(Main, Error, "cannot spawn executable %s, error=%s",
+        DS2LOG(Error, "cannot spawn executable %s, error=%s",
                _executablePath.c_str(), strerror(errno));
       }
     }

--- a/Sources/Host/POSIX/ProcessSpawner.cpp
+++ b/Sources/Host/POSIX/ProcessSpawner.cpp
@@ -13,6 +13,7 @@
 #if defined(__linux__)
 #include "DebugServer2/Host/Linux/ExtraWrappers.h"
 #endif
+#include "DebugServer2/Host/Platform.h"
 #include "DebugServer2/Host/ProcessSpawner.h"
 #include "DebugServer2/Utils/Log.h"
 

--- a/Sources/Host/Windows/Platform.cpp
+++ b/Sources/Host/Windows/Platform.cpp
@@ -353,6 +353,17 @@ bool Platform::GetCurrentEnvironment(EnvironmentBlock &env) {
   return true;
 }
 
+ErrorCode Platform::TranslateError(DWORD error) {
+  switch (error) {
+  default:
+    // Make sure we catch unknown error codes during development.
+    DS2ASSERT(false);
+    return kErrorUnknown;
+  }
+}
+
+ErrorCode Platform::TranslateError() { return TranslateError(GetLastError()); }
+
 std::wstring Platform::NarrowToWideString(std::string const &s) {
   std::vector<wchar_t> res;
   int size;

--- a/Sources/Host/Windows/Platform.cpp
+++ b/Sources/Host/Windows/Platform.cpp
@@ -356,9 +356,7 @@ bool Platform::GetCurrentEnvironment(EnvironmentBlock &env) {
 ErrorCode Platform::TranslateError(DWORD error) {
   switch (error) {
   default:
-    // Make sure we catch unknown error codes during development.
-    DS2ASSERT(false);
-    return kErrorUnknown;
+    DS2BUG("unknown error code: %d", error);
   }
 }
 

--- a/Sources/Host/Windows/Platform.cpp
+++ b/Sources/Host/Windows/Platform.cpp
@@ -31,6 +31,7 @@
 
 namespace ds2 {
 namespace Host {
+namespace Windows {
 
 void Platform::Initialize() {
   // Disable buffering on stdout (where we print logs). When running on
@@ -374,6 +375,7 @@ std::string Platform::WideToNarrowString(std::wstring const &s) {
   WideCharToMultiByte(CP_UTF8, 0, s.c_str(), -1, res.data(), size, nullptr,
                       nullptr);
   return res.data();
+}
 }
 }
 }

--- a/Sources/Host/Windows/ProcessSpawner.cpp
+++ b/Sources/Host/Windows/ProcessSpawner.cpp
@@ -106,13 +106,16 @@ ErrorCode ProcessSpawner::run(std::function<bool()> preExecAction) {
       wideWorkingDirectory.empty() ? nullptr : wideWorkingDirectory.c_str(),
       &si, &pi);
 
+  if (!result)
+    return Platform::TranslateError();
+
   _pid = pi.dwProcessId;
   _handle = pi.hProcess;
 
   _tid = pi.dwThreadId;
   _threadHandle = pi.hThread;
 
-  return result ? kSuccess : kErrorUnknown;
+  return kSuccess;
 }
 }
 }

--- a/Sources/Support/POSIX/FaultHandler.cpp
+++ b/Sources/Support/POSIX/FaultHandler.cpp
@@ -49,7 +49,7 @@ private:
     DS2ASSERT(SignalCodeNames[si->si_signo].find(si->si_code) !=
               SignalCodeNames[si->si_signo].end());
 
-    DS2LOG(Main, Error, "received %s with code %s at address %p, crashing",
+    DS2LOG(Error, "received %s with code %s at address %p, crashing",
            SignalNames[si->si_signo],
            SignalCodeNames[si->si_signo][si->si_code], si->si_addr);
 

--- a/Sources/Target/Linux/ARM/ThreadARM.cpp
+++ b/Sources/Target/Linux/ARM/ThreadARM.cpp
@@ -31,7 +31,7 @@ static ErrorCode PrepareThumbSoftwareSingleStep(
   ErrorCode error;
   uint32_t insns[2];
 
-  DS2LOG(Architecture, Debug, "process=%p", process);
+  DS2LOG(Debug, "process=%p", process);
 
   error = process->readMemory(pc, insns, sizeof(insns));
   if (error != ds2::kSuccess)
@@ -48,7 +48,7 @@ static ErrorCode PrepareThumbSoftwareSingleStep(
     return ds2::kSuccess;
   }
 
-  DS2LOG(Architecture, Debug, "Thumb branch/IT found at %#x (it=%s[%u])", pc,
+  DS2LOG(Debug, "Thumb branch/IT found at %#x (it=%s[%u])", pc,
          info.it ? "true" : "false", info.it ? info.itCount : 0);
 
   //
@@ -86,7 +86,7 @@ static ErrorCode PrepareThumbSoftwareSingleStep(
           info.type == ds2::Architecture::ARM::kBranchTypeBLX_i ||
           info.type == ds2::Architecture::ARM::kBranchTypeBLX_r);
 
-  DS2LOG(Architecture, Debug, "link=%d", link);
+  DS2LOG(Debug, "link=%d", link);
   //
   // If it's a conditional branch, we need to move
   // the nextPC by the size of this instruction.
@@ -227,7 +227,7 @@ PrepareARMSoftwareSingleStep(Process *process, uint32_t pc,
 
   uint32_t address;
 
-  DS2LOG(Architecture, Debug, "ARM branch found at %#x", pc);
+  DS2LOG(Debug, "ARM branch found at %#x", pc);
 
   link = (info.type == ds2::Architecture::ARM::kBranchTypeBL_i ||
           info.type == ds2::Architecture::ARM::kBranchTypeBLX_i ||
@@ -361,9 +361,9 @@ ErrorCode Thread::prepareSoftwareSingleStep(Address const &address) {
                                          nextPCSize, branchPC, branchPCSize);
   }
 
-  DS2LOG(Architecture, Debug,
-         "PC=%#x, branchPC=%#x[size=%d, link=%s] nextPC=%#x[size=%d]", pc,
-         branchPC, branchPCSize, link ? "true" : "false", nextPC, nextPCSize);
+  DS2LOG(Debug, "PC=%#x, branchPC=%#x[size=%d, link=%s] nextPC=%#x[size=%d]",
+         pc, branchPC, branchPCSize, link ? "true" : "false", nextPC,
+         nextPCSize);
 
   if (branchPC != static_cast<uint32_t>(-1)) {
     DS2ASSERT(branchPCSize != 0);

--- a/Sources/Target/Linux/Thread.cpp
+++ b/Sources/Target/Linux/Thread.cpp
@@ -186,7 +186,7 @@ ErrorCode Thread::updateTrapInfo(int waitStatus) {
     _trap.reason = TrapInfo::kReasonThreadNew;
   }
 
-  updateState(true);
+  updateState();
 
   if (_trap.event == TrapInfo::kEventStop) {
     ProcessThreadId ptid(process()->pid(), tid());
@@ -234,9 +234,7 @@ ErrorCode Thread::updateTrapInfo(int waitStatus) {
   return error;
 }
 
-void Thread::updateState() { updateState(false); }
-
-void Thread::updateState(bool force) {
+void Thread::updateState() {
   if (!process()->isAlive()) {
     _state = kTerminated;
     return;

--- a/Sources/Target/Linux/Thread.cpp
+++ b/Sources/Target/Linux/Thread.cpp
@@ -54,7 +54,7 @@ ErrorCode Thread::suspend() {
     error = process()->ptrace().wait(ProcessThreadId(process()->pid(), tid()),
                                      true, &status);
     if (error != kSuccess) {
-      DS2LOG(Target, Error, "failed to wait for tid %d, error=%s\n", tid(),
+      DS2LOG(Error, "failed to wait for tid %d, error=%s\n", tid(),
              strerror(errno));
       return error;
     }
@@ -72,7 +72,7 @@ ErrorCode Thread::suspend() {
 ErrorCode Thread::step(int signal, Address const &address) {
   ErrorCode error = kSuccess;
   if (_state == kStopped || _state == kStepped) {
-    DS2LOG(Target, Debug, "stepping tid %d", tid());
+    DS2LOG(Debug, "stepping tid %d", tid());
     if (process()->isSingleStepSupported()) {
       ProcessInfo info;
 
@@ -193,8 +193,8 @@ ErrorCode Thread::updateTrapInfo(int waitStatus) {
 
     error = process()->ptrace().getSigInfo(ptid, si);
     if (error != kSuccess) {
-      DS2LOG(Target, Warning, "unable to get siginfo_t for tid %d, error=%s",
-             tid(), strerror(errno));
+      DS2LOG(Warning, "unable to get siginfo_t for tid %d, error=%s", tid(),
+             strerror(errno));
       return error;
     }
 
@@ -224,7 +224,7 @@ ErrorCode Thread::updateTrapInfo(int waitStatus) {
       //
       if ((si.si_code == SI_USER || si.si_code == SI_TKILL) &&
           si.si_pid != tid()) {
-        DS2LOG(Target, Warning,
+        DS2LOG(Warning,
                "tid %d received a signal from an external source (sender=%d)",
                tid(), si.si_pid);
       }

--- a/Sources/Target/POSIX/Process.cpp
+++ b/Sources/Target/POSIX/Process.cpp
@@ -105,7 +105,7 @@ ds2::Target::Process *Process::Attach(ProcessId pid) {
   //
   ErrorCode error = process->ptrace().attach(pid);
   if (error != kSuccess) {
-    DS2LOG(Target, Error, "ptrace attach failed: %s", strerror(errno));
+    DS2LOG(Error, "ptrace attach failed: %s", strerror(errno));
     goto fail;
   }
 
@@ -137,7 +137,7 @@ ds2::Target::Process *Process::Create(ProcessSpawner &spawner) {
     goto fail;
 
   pid = spawner.pid();
-  DS2LOG(Target, Debug, "created process %d", pid);
+  DS2LOG(Debug, "created process %d", pid);
 
   //
   // Wait the process.

--- a/Sources/Target/POSIX/Thread.cpp
+++ b/Sources/Target/POSIX/Thread.cpp
@@ -27,9 +27,6 @@ ErrorCode Thread::updateTrapInfo(int waitStatus) {
 
   _trap.clear();
 
-  _trap.pid = _process->pid();
-  _trap.tid = tid();
-
   if (WIFEXITED(waitStatus)) {
     _trap.event = TrapInfo::kEventExit;
     _trap.status = WEXITSTATUS(waitStatus);

--- a/Sources/Target/ProcessBase.cpp
+++ b/Sources/Target/ProcessBase.cpp
@@ -157,7 +157,7 @@ void ProcessBase::insert(ThreadBase *thread) {
                                       static_cast<Thread *>(thread))).second)
     return;
 
-  DS2LOG(Target, Info, "[New Thread %p (LWP %llu)]", thread,
+  DS2LOG(Info, "[New Thread %p (LWP %llu)]", thread,
          (unsigned long long)thread->tid());
 }
 
@@ -169,7 +169,7 @@ void ProcessBase::removeThread(ThreadId tid) {
   Thread *thread = it->second;
   _threads.erase(it);
 
-  DS2LOG(Target, Info, "[Thread %p (LWP %llu) exited]", thread,
+  DS2LOG(Info, "[Thread %p (LWP %llu) exited]", thread,
          (unsigned long long)thread->tid());
 
   delete thread;
@@ -209,7 +209,7 @@ ErrorCode ProcessBase::afterResume() {
 
     for (auto it : _threads) {
       if (bpm->hit(it.second)) {
-        DS2LOG(Target, Info, "hit breakpoint for tid %llu",
+        DS2LOG(Info, "hit breakpoint for tid %llu",
                (unsigned long long)it.second->tid());
       }
     }

--- a/Sources/Target/ThreadBase.cpp
+++ b/Sources/Target/ThreadBase.cpp
@@ -24,7 +24,5 @@ ThreadBase::~ThreadBase() {}
 ErrorCode ThreadBase::prepareSoftwareSingleStep(Address const &) {
   return kErrorUnsupported;
 }
-
-void ThreadBase::updateState() {}
 }
 }

--- a/Sources/Target/Windows/Process.cpp
+++ b/Sources/Target/Windows/Process.cpp
@@ -44,7 +44,6 @@ ErrorCode Process::initialize(ProcessId pid, HANDLE handle, ThreadId tid,
   _handle = handle;
 
   _currentThread = new Thread(this, tid, threadHandle);
-  _currentThread->updateTrapInfo();
 
   return kSuccess;
 }

--- a/Sources/Target/Windows/Process.cpp
+++ b/Sources/Target/Windows/Process.cpp
@@ -72,9 +72,15 @@ ErrorCode Process::wait(int *status, bool hang) {
 
   switch (de.dwDebugEventCode) {
   case CREATE_PROCESS_DEBUG_EVENT:
-    // Nothing to do when the process is created, just continue.
-    // TODO(sas): We might have to release contents of the
-    // CREATE_PROCESS_DEBUG_INFO structure.
+#define CHECK_AND_CLOSE(HAN)                                                   \
+  do {                                                                         \
+    if ((de.u.CreateProcessInfo.HAN) != NULL)                                  \
+      CloseHandle(de.u.CreateProcessInfo.HAN);                                 \
+  } while (0)
+    CHECK_AND_CLOSE(hFile);
+    CHECK_AND_CLOSE(hProcess);
+    CHECK_AND_CLOSE(hThread);
+#undef CHECK_AND_CLOSE
     return kSuccess;
 
   case EXIT_PROCESS_DEBUG_EVENT:

--- a/Sources/Target/Windows/Process.cpp
+++ b/Sources/Target/Windows/Process.cpp
@@ -11,6 +11,7 @@
 #define __DS2_LOG_CLASS_NAME__ "Target::Process"
 
 #include "DebugServer2/Host/Platform.h"
+#include "DebugServer2/Host/Platform.h"
 #include "DebugServer2/Target/Process.h"
 #include "DebugServer2/Target/Thread.h"
 #include "DebugServer2/Utils/Log.h"
@@ -55,7 +56,7 @@ ErrorCode Process::detach() { return kErrorUnsupported; }
 ErrorCode Process::terminate() {
   BOOL result = TerminateProcess(_handle, 0);
   if (!result)
-    return kErrorUnknown;
+    return Platform::TranslateError();
 
   _terminated = true;
   return kSuccess;
@@ -68,7 +69,7 @@ ErrorCode Process::wait(int *status, bool hang) {
 
   BOOL result = WaitForDebugEvent(&de, hang ? INFINITE : 0);
   if (!result)
-    return kErrorUnknown;
+    return Platform::TranslateError();
 
   auto threadIt = _threads.find(de.dwThreadId);
 

--- a/Sources/Target/Windows/Process.cpp
+++ b/Sources/Target/Windows/Process.cpp
@@ -98,8 +98,7 @@ ErrorCode Process::wait(int *status, bool hang) {
   } break;
 
   default:
-    // We should have an exhaustive list of debug events.
-    DS2ASSERT(false);
+    DS2BUG("unknown debug event code: %d", de.dwDebugEventCode);
   }
 
   return kSuccess;

--- a/Sources/Target/Windows/Process.cpp
+++ b/Sources/Target/Windows/Process.cpp
@@ -127,6 +127,36 @@ ErrorCode Process::resume(int signal, std::set<Thread *> const &excluded) {
   return kSuccess;
 }
 
+ErrorCode Process::readMemory(Address const &address, void *data, size_t length,
+                              size_t *nread) {
+  BOOL result =
+      ReadProcessMemory(_handle, reinterpret_cast<LPCVOID>(address.value()),
+                        data, length, reinterpret_cast<SIZE_T *>(nread));
+
+  if (!result) {
+    auto error = GetLastError();
+    if (error != ERROR_PARTIAL_COPY)
+      return Host::Platform::TranslateError(error);
+  }
+
+  return kSuccess;
+}
+
+ErrorCode Process::writeMemory(Address const &address, void const *data,
+                               size_t length, size_t *nwritten) {
+  BOOL result =
+      WriteProcessMemory(_handle, reinterpret_cast<LPVOID>(address.value()),
+                         data, length, reinterpret_cast<SIZE_T *>(nwritten));
+
+  if (!result) {
+    auto error = GetLastError();
+    if (error != ERROR_PARTIAL_COPY)
+      return Host::Platform::TranslateError(error);
+  }
+
+  return kSuccess;
+}
+
 ErrorCode Process::updateInfo() {
   if (_info.pid == _pid)
     return kErrorAlreadyExist;

--- a/Sources/Target/Windows/Process.cpp
+++ b/Sources/Target/Windows/Process.cpp
@@ -82,11 +82,11 @@ ErrorCode Process::wait(int *status, bool hang) {
     return kSuccess;
 
   case CREATE_THREAD_DEBUG_EVENT:
-    DS2LOG(Target, Fatal, "debug event CREATE_THREAD");
+    DS2LOG(Fatal, "debug event CREATE_THREAD");
   case EXIT_THREAD_DEBUG_EVENT:
-    DS2LOG(Target, Fatal, "debug event EXIT_THREAD");
+    DS2LOG(Fatal, "debug event EXIT_THREAD");
   case RIP_EVENT:
-    DS2LOG(Target, Fatal, "debug event RIP");
+    DS2LOG(Fatal, "debug event RIP");
 
   case EXCEPTION_DEBUG_EVENT:
   case LOAD_DLL_DEBUG_EVENT:
@@ -114,12 +114,12 @@ ErrorCode Process::resume(int signal, std::set<Thread *> const &excluded) {
         thread->state() == Thread::kStepped) {
       Architecture::CPUState state;
       thread->readCPUState(state);
-      DS2LOG(Target, Debug, "resuming tid %d from pc %#llx", thread->tid(),
+      DS2LOG(Debug, "resuming tid %d from pc %#llx", thread->tid(),
              (unsigned long long)state.pc());
       ErrorCode error = thread->resume(signal);
       if (error != kSuccess) {
-        DS2LOG(Target, Warning, "failed resuming tid %d, error=%d",
-               thread->tid(), error);
+        DS2LOG(Warning, "failed resuming tid %d, error=%d", thread->tid(),
+               error);
       }
     }
   });
@@ -205,7 +205,7 @@ ds2::Target::Process *Process::Create(ProcessSpawner &spawner) {
   if (error != kSuccess)
     goto fail;
 
-  DS2LOG(Target, Debug, "created process %d", spawner.pid());
+  DS2LOG(Debug, "created process %d", spawner.pid());
 
   //
   // Wait the process.

--- a/Sources/Target/Windows/Thread.cpp
+++ b/Sources/Target/Windows/Thread.cpp
@@ -72,6 +72,9 @@ void Thread::updateState(DEBUG_EVENT const &de) {
     break;
 
   case LOAD_DLL_DEBUG_EVENT:
+    if (de.u.LoadDll.hFile != NULL)
+      CloseHandle(de.u.LoadDll.hFile);
+
   case UNLOAD_DLL_DEBUG_EVENT:
   case OUTPUT_DEBUG_STRING_EVENT:
     _state = kStopped;

--- a/Sources/Target/Windows/Thread.cpp
+++ b/Sources/Target/Windows/Thread.cpp
@@ -80,8 +80,7 @@ void Thread::updateState(DEBUG_EVENT const &de) {
     break;
 
   default:
-    // Some debug events need to be handled at the process layer.
-    DS2ASSERT(false);
+    DS2BUG("unknown debug event code: %d", de.dwDebugEventCode);
   }
 }
 }

--- a/Sources/Target/Windows/Thread.cpp
+++ b/Sources/Target/Windows/Thread.cpp
@@ -59,6 +59,25 @@ ErrorCode Thread::resume(int signal, Address const &address) {
 
   return error;
 }
+
+void Thread::updateState() {}
+
+void Thread::updateState(DEBUG_EVENT const &de) {
+  DS2ASSERT(de.dwThreadId == _tid);
+
+  switch (de.dwDebugEventCode) {
+  case EXCEPTION_DEBUG_EVENT:
+  case LOAD_DLL_DEBUG_EVENT:
+  case UNLOAD_DLL_DEBUG_EVENT:
+  case OUTPUT_DEBUG_STRING_EVENT:
+    _state = kStopped;
+    break;
+
+  default:
+    // Some debug events need to be handled at the process layer.
+    DS2ASSERT(false);
+  }
+}
 }
 }
 }

--- a/Sources/Target/Windows/Thread.cpp
+++ b/Sources/Target/Windows/Thread.cpp
@@ -52,7 +52,6 @@ ErrorCode Thread::resume(int signal, Address const &address) {
       return Host::Platform::TranslateError();
 
     _state = kRunning;
-    _trap.signal = 0;
   } else if (_state == kTerminated) {
     error = kErrorProcessNotFound;
   }
@@ -67,10 +66,17 @@ void Thread::updateState(DEBUG_EVENT const &de) {
 
   switch (de.dwDebugEventCode) {
   case EXCEPTION_DEBUG_EVENT:
+    _state = kStopped;
+    _trap.event = TrapInfo::kEventTrap;
+    _trap.reason = TrapInfo::kReasonNone;
+    break;
+
   case LOAD_DLL_DEBUG_EVENT:
   case UNLOAD_DLL_DEBUG_EVENT:
   case OUTPUT_DEBUG_STRING_EVENT:
     _state = kStopped;
+    _trap.event = TrapInfo::kEventNone;
+    _trap.reason = TrapInfo::kReasonNone;
     break;
 
   default:

--- a/Sources/Target/Windows/Thread.cpp
+++ b/Sources/Target/Windows/Thread.cpp
@@ -10,6 +10,7 @@
 
 #define __DS2_LOG_CLASS_NAME__ "Target::Thread"
 
+#include "DebugServer2/Host/Platform.h"
 #include "DebugServer2/Target/Process.h"
 #include "DebugServer2/Target/Windows/Thread.h"
 #include "DebugServer2/Utils/Log.h"
@@ -48,7 +49,7 @@ ErrorCode Thread::resume(int signal, Address const &address) {
 
     BOOL result = ContinueDebugEvent(_process->pid(), _tid, DBG_CONTINUE);
     if (!result)
-      return kErrorUnknown;
+      return Host::Platform::TranslateError();
 
     _state = kRunning;
     _trap.signal = 0;

--- a/Sources/Target/Windows/X86/ThreadX86.cpp
+++ b/Sources/Target/Windows/X86/ThreadX86.cpp
@@ -10,6 +10,7 @@
 
 #define __DS2_LOG_CLASS_NAME__ "Target::Thread"
 
+#include "DebugServer2/Host/Platform.h"
 #include "DebugServer2/Target/Thread.h"
 #include "DebugServer2/Utils/Log.h"
 
@@ -28,11 +29,8 @@ ErrorCode Thread::readCPUState(Architecture::CPUState &state) {
                          CONTEXT_EXTENDED_REGISTERS; // SSE registers.
 
   BOOL result = GetThreadContext(_handle, &context);
-  if (!result) {
-    DS2LOG(Target, Error, "Unable to GetThreadContext: %d, handle=%p",
-           GetLastError(), _handle);
-    return kErrorUnknown;
-  }
+  if (!result)
+    return Host::Platform::TranslateError();
 
   // GP registers + segment selectors.
   state.gp.eax = context.Eax;

--- a/Sources/Utils/Log.cpp
+++ b/Sources/Utils/Log.cpp
@@ -20,7 +20,6 @@
 
 namespace {
 
-uint64_t sLogMask;
 int sLogLevel;
 bool sColorsEnabled;
 // stderr is handled a bit differently on Windows, especially when running
@@ -38,18 +37,13 @@ uint32_t GetLogLevel() { return sLogLevel; }
 
 void SetLogLevel(uint32_t level) { sLogLevel = level; }
 
-void SetLogMask(uint64_t mask) { sLogMask = mask; }
-
 void SetLogColorsEnabled(bool enabled) { sColorsEnabled = enabled; }
 
 void SetLogOutputStream(FILE *stream) { sOutputStream = stream; }
 
-void vLog(int category, int level, char const *classname, char const *funcname,
+void vLog(int level, char const *classname, char const *funcname,
           char const *format, va_list ap) {
   if (sLogLevel > level)
-    return;
-
-  if ((sLogMask & (1ULL << category)) == 0)
     return;
 
   std::stringstream ss;
@@ -118,12 +112,12 @@ void vLog(int category, int level, char const *classname, char const *funcname,
     exit(EXIT_FAILURE);
 }
 
-void Log(int category, int level, char const *classname, char const *funcname,
+void Log(int level, char const *classname, char const *funcname,
          char const *format, ...) {
   va_list ap;
 
   va_start(ap, format);
-  vLog(category, level, classname, funcname, format, ap);
+  vLog(level, classname, funcname, format, ap);
   va_end(ap);
 }
 }

--- a/Sources/Utils/Log.cpp
+++ b/Sources/Utils/Log.cpp
@@ -109,7 +109,7 @@ void vLog(int level, char const *classname, char const *funcname,
   fflush(sOutputStream);
 
   if (level == kLogLevelFatal)
-    exit(EXIT_FAILURE);
+    abort();
 }
 
 void Log(int level, char const *classname, char const *funcname,


### PR DESCRIPTION
With this, we can single-step through the execution of a process, and get assembly output.

```
(lldb) si
Process 37584 resuming
Process 37584 stopped
* thread #1: tid = 0x7ccc, 0x77500884, name = '<NONE>', stop reason = signal SIGTRAP
    frame #0: 0x77500884
-> 0x77500884: movl   %ebx, 0x8(%esp)
   0x77500888: jmp    0x7751accf
   0x7750088d: leal   (%ecx), %ecx
   0x77500890: movl   %esp, %edx
(lldb)
```