### PR TITLE
Fixed comment typo in SoftwareBreakpointManager::hit.

### DIFF
--- a/Sources/Architecture/X86/SoftwareBreakpointManager.cpp
+++ b/Sources/Architecture/X86/SoftwareBreakpointManager.cpp
@@ -43,7 +43,7 @@ bool SoftwareBreakpointManager::hit(Target::Thread *thread) {
   ds2::Architecture::CPUState state;
 
   //
-  // Ignore hardware signle-stepping.
+  // Ignore hardware single-stepping.
   //
   if (thread->state() == Target::Thread::kStepped)
     return true;


### PR DESCRIPTION
Some drive-by pull while showing how something works to a friend and noticed this typo.