### PR TITLE
Move decoding of stop reasons to OS-specific code.

### DIFF
--- a/Headers/DebugServer2/Architecture/Registers.h
+++ b/Headers/DebugServer2/Architecture/Registers.h
@@ -23,23 +23,8 @@
 #elif defined(ARCH_X86_64)
 #include "DebugServer2/Architecture/I386/Registers.h"
 #include "DebugServer2/Architecture/X86_64/Registers.h"
-#elif defined(ARCH_MIPS)
-#include "DebugServer2/Architecture/MIPS/Registers.h"
-#elif defined(ARCH_MIPS64)
-#include "DebugServer2/Architecture/MIPS/Registers.h"
-#include "DebugServer2/Architecture/MIPS64/Registers.h"
-#elif defined(ARCH_PPC)
-#include "DebugServer2/Architecture/PowerPC/Registers.h"
-#elif defined(ARCH_PPC64)
-#include "DebugServer2/Architecture/PowerPC/Registers.h"
-#include "DebugServer2/Architecture/PowerPC64/Registers.h"
-#elif defined(ARCH_SPARC)
-#include "DebugServer2/Architecture/SPARC/Registers.h"
-#elif defined(ARCH_SPARC64)
-#include "DebugServer2/Architecture/SPARC/Registers.h"
-#include "DebugServer2/Architecture/SPARC64/Registers.h"
 #else
-#error "Unknown target architecture."
+#error "Architecture not supported."
 #endif
 
 #endif // !__DebugServer2_Architecture_Registers_h

--- a/Headers/DebugServer2/Host/Platform.h
+++ b/Headers/DebugServer2/Host/Platform.h
@@ -17,18 +17,8 @@
 #include "DebugServer2/Host/Windows/Platform.h"
 #elif defined(__linux__)
 #include "DebugServer2/Host/Linux/Platform.h"
-#elif defined(__FreeBSD__)
-#include "DebugServer2/Host/FreeBSD/Platform.h"
-#elif defined(__NetBSD__)
-#include "DebugServer2/Host/NetBSD/Platform.h"
-#elif defined(__OpenBSD__)
-#include "DebugServer2/Host/OpenBSD/Platform.h"
-#elif defined(__QNX__)
-#include "DebugServer2/Host/QNX/Platform.h"
-#elif defined(sun)
-#include "DebugServer2/Host/Solaris/Platform.h"
 #else
-#error "Your platform is not supported."
+#error "Target not supported."
 #endif
 
 namespace ds2 {
@@ -38,18 +28,8 @@ namespace Host {
 using Windows::Platform;
 #elif defined(__linux__)
 using Linux::Platform;
-#elif defined(__FreeBSD__)
-using FreeBSD::Platform;
-#elif defined(__NetBSD__)
-using NetBSD::Platform;
-#elif defined(__OpenBSD__)
-using OpenBSD::Platform;
-#elif defined(__QNX__)
-using QNX::Platform;
-#elif defined(sun)
-using Solaris::Platform;
 #else
-#error "Your platform is not supported."
+#error "Target not supported."
 #endif
 }
 }

--- a/Headers/DebugServer2/Target/ThreadBase.h
+++ b/Headers/DebugServer2/Target/ThreadBase.h
@@ -27,7 +27,7 @@ public:
 protected:
   Process *_process;
   ThreadId _tid;
-  StopInfo _trap;
+  StopInfo _stopInfo;
   State _state;
 
 protected:
@@ -39,7 +39,7 @@ public:
 public:
   inline Process *process() const { return _process; }
   inline ThreadId tid() const { return _tid; }
-  inline StopInfo const &trapInfo() const { return _trap; }
+  inline StopInfo const &stopInfo() const { return _stopInfo; }
 
 public:
   virtual ErrorCode terminate() = 0;
@@ -61,7 +61,7 @@ public:
   virtual ErrorCode writeCPUState(Architecture::CPUState const &state) = 0;
 
 public:
-  inline uint32_t core() const { return _trap.core; }
+  inline uint32_t core() const { return _stopInfo.core; }
 
 protected:
   friend class ProcessBase;

--- a/Headers/DebugServer2/Target/Windows/Process.h
+++ b/Headers/DebugServer2/Target/Windows/Process.h
@@ -21,6 +21,7 @@ namespace Windows {
 class Process : public Target::ProcessBase {
 protected:
   HANDLE _handle;
+  BreakpointManager *_breakpointManager;
   bool _terminated;
 
 protected:
@@ -67,7 +68,7 @@ public:
   virtual ErrorCode updateInfo();
 
 public:
-  virtual BreakpointManager *breakpointManager() const { return nullptr; }
+  virtual BreakpointManager *breakpointManager() const;
   virtual WatchpointManager *watchpointManager() const { return nullptr; }
 
 public:

--- a/Headers/DebugServer2/Types.h
+++ b/Headers/DebugServer2/Types.h
@@ -91,12 +91,9 @@ typedef std::map<std::string, std::string> EnvironmentBlock;
 struct StopInfo {
   enum Event {
     kEventNone,
-    kEventExit,
-#if !defined(_WIN32)
-    kEventKill,
-#endif
-    kEventTrap,
     kEventStop,
+    kEventExit,
+    kEventKill,
   };
 
   enum Reason {

--- a/Headers/DebugServer2/Types.h
+++ b/Headers/DebugServer2/Types.h
@@ -114,6 +114,7 @@ struct StopInfo {
   };
 
   Event event;
+  Reason reason;
   uint32_t core;
   int status;
 #if !defined(_WIN32)
@@ -124,6 +125,7 @@ struct StopInfo {
 
   inline void clear() {
     event = kEventNone;
+    reason = kReasonNone;
     core = 0;
     status = 0;
 #if !defined(_WIN32)

--- a/Headers/DebugServer2/Utils/Log.h
+++ b/Headers/DebugServer2/Utils/Log.h
@@ -68,13 +68,14 @@ void Log(int level, char const *classname, char const *funcname,
     DS2LOG(Fatal, "bug at %s:%d:" MESSAGE, __FILE__, __LINE__, ##__VA_ARGS__); \
     DS2_UNREACHABLE();                                                         \
   } while (0)
-#elif defined(_MSVC_VER)
+#elif defined(_MSC_VER)
 #define DS2BUG(MESSAGE, ...)                                                   \
   do {                                                                         \
     DS2LOG(Fatal, "bug at %s:%d:" MESSAGE, __FILE__, __LINE__, __VA_ARGS__);   \
     DS2_UNREACHABLE();                                                         \
   } while (0)
 #else
+#error "Compiler not supported."
 #endif
 }
 

--- a/Sources/GDBRemote/DebugSessionImpl.cpp
+++ b/Sources/GDBRemote/DebugSessionImpl.cpp
@@ -165,7 +165,7 @@ ErrorCode DebugSessionImpl::queryStopCode(Session &session,
     return kErrorProcessNotFound;
 
   bool readRegisters = true;
-  StopInfo const &trap = thread->trapInfo();
+  StopInfo const &trap = thread->stopInfo();
 
   Architecture::CPUState state;
 

--- a/Sources/GDBRemote/DebugSessionImpl.cpp
+++ b/Sources/GDBRemote/DebugSessionImpl.cpp
@@ -190,18 +190,14 @@ ErrorCode DebugSessionImpl::queryStopCode(Session &session,
     readRegisters = false;
     break;
 #endif
-  case StopInfo::kEventTrap:
-    stop.event = StopCode::kSignal;
-    stop.reason = StopInfo::kReasonBreakpoint;
-#if !defined(_WIN32)
-    stop.signal = trap.signal;
-#endif
-    break;
   case StopInfo::kEventStop:
     stop.event = StopCode::kSignal;
     stop.reason = StopInfo::kReasonSignalStop;
 #if !defined(_WIN32)
     stop.signal = trap.signal;
+    // TODO(sas): Push this down to OS-specific code.
+    if (stop.signal == SIGTRAP)
+      stop.reason = StopInfo::kReasonBreakpoint;
 #endif
     break;
   }

--- a/Sources/Host/Windows/Platform.cpp
+++ b/Sources/Host/Windows/Platform.cpp
@@ -23,12 +23,6 @@
 #include <windows.h>
 #include <winsock2.h>
 
-// Note(sas): This is used to disable deprecation warnings for GetVersion(). We
-// can remove this when we get rid of calls to this function.
-#if defined(_MSVC_VER)
-#pragma warning(disable : 4996)
-#endif
-
 namespace ds2 {
 namespace Host {
 namespace Windows {

--- a/Sources/Target/Linux/Process.cpp
+++ b/Sources/Target/Linux/Process.cpp
@@ -211,13 +211,11 @@ ErrorCode Process::wait(int *rstatus, bool hang) {
       removeThread(tid);
       goto continue_waiting;
 
-    case StopInfo::kEventTrap:
-      DS2LOG(Debug, "stopped tid=%d status=%#x signal=%s", tid, status,
-             strsignal(WSTOPSIG(status)));
-      break;
-
     case StopInfo::kEventStop:
       signal = _currentThread->_trap.signal;
+
+      DS2LOG(Debug, "stopped tid=%d status=%#x signal=%s", tid, status,
+             strsignal(signal));
 
       if (signal == SIGSTOP || signal == SIGCHLD || signal == SIGRTMIN) {
         //

--- a/Sources/Target/Linux/Process.cpp
+++ b/Sources/Target/Linux/Process.cpp
@@ -185,7 +185,7 @@ ErrorCode Process::wait(int *rstatus, bool hang) {
 
     _currentThread->updateStopInfo(status);
 
-    switch (_currentThread->_trap.event) {
+    switch (_currentThread->_stopInfo.event) {
     case StopInfo::kEventNone:
       _currentThread->resume();
       goto continue_waiting;
@@ -212,7 +212,7 @@ ErrorCode Process::wait(int *rstatus, bool hang) {
       goto continue_waiting;
 
     case StopInfo::kEventStop:
-      signal = _currentThread->_trap.signal;
+      signal = _currentThread->_stopInfo.signal;
 
       DS2LOG(Debug, "stopped tid=%d status=%#x signal=%s", tid, status,
              strsignal(signal));

--- a/Sources/Target/POSIX/Thread.cpp
+++ b/Sources/Target/POSIX/Thread.cpp
@@ -35,18 +35,8 @@ ErrorCode Thread::updateStopInfo(int waitStatus) {
     _trap.status = WEXITSTATUS(waitStatus);
     _trap.signal = WTERMSIG(waitStatus);
   } else if (WIFSTOPPED(waitStatus)) {
+    _trap.event = StopInfo::kEventStop;
     _trap.signal = WSTOPSIG(waitStatus);
-    switch (_trap.signal) {
-    case SIGTRAP:
-      _trap.event = StopInfo::kEventTrap;
-      break;
-    case SIGSTOP:
-      _trap.event = StopInfo::kEventStop;
-      break;
-    default:
-      _trap.event = StopInfo::kEventStop;
-      break;
-    }
   }
 
   return error;

--- a/Sources/Target/POSIX/Thread.cpp
+++ b/Sources/Target/POSIX/Thread.cpp
@@ -25,18 +25,18 @@ Thread::Thread(ds2::Target::Process *process, ThreadId tid)
 ErrorCode Thread::updateStopInfo(int waitStatus) {
   ErrorCode error = kSuccess;
 
-  _trap.clear();
+  _stopInfo.clear();
 
   if (WIFEXITED(waitStatus)) {
-    _trap.event = StopInfo::kEventExit;
-    _trap.status = WEXITSTATUS(waitStatus);
+    _stopInfo.event = StopInfo::kEventExit;
+    _stopInfo.status = WEXITSTATUS(waitStatus);
   } else if (WIFSIGNALED(waitStatus)) {
-    _trap.event = StopInfo::kEventKill;
-    _trap.status = WEXITSTATUS(waitStatus);
-    _trap.signal = WTERMSIG(waitStatus);
+    _stopInfo.event = StopInfo::kEventKill;
+    _stopInfo.status = WEXITSTATUS(waitStatus);
+    _stopInfo.signal = WTERMSIG(waitStatus);
   } else if (WIFSTOPPED(waitStatus)) {
-    _trap.event = StopInfo::kEventStop;
-    _trap.signal = WSTOPSIG(waitStatus);
+    _stopInfo.event = StopInfo::kEventStop;
+    _stopInfo.signal = WSTOPSIG(waitStatus);
   }
 
   return error;

--- a/Sources/Target/Windows/Process.cpp
+++ b/Sources/Target/Windows/Process.cpp
@@ -26,7 +26,8 @@ namespace Target {
 namespace Windows {
 
 Process::Process()
-    : Target::ProcessBase(), _handle(nullptr), _terminated(false) {}
+    : Target::ProcessBase(), _handle(nullptr), _breakpointManager(nullptr),
+      _terminated(false) {}
 
 Process::~Process() { CloseHandle(_handle); }
 

--- a/Sources/Target/Windows/Thread.cpp
+++ b/Sources/Target/Windows/Thread.cpp
@@ -67,8 +67,8 @@ void Thread::updateState(DEBUG_EVENT const &de) {
   switch (de.dwDebugEventCode) {
   case EXCEPTION_DEBUG_EVENT:
     _state = kStopped;
-    _trap.event = StopInfo::kEventStop;
-    _trap.reason = StopInfo::kReasonBreakpoint;
+    _stopInfo.event = StopInfo::kEventStop;
+    _stopInfo.reason = StopInfo::kReasonBreakpoint;
     break;
 
   case LOAD_DLL_DEBUG_EVENT: {
@@ -119,8 +119,8 @@ void Thread::updateState(DEBUG_EVENT const &de) {
   case UNLOAD_DLL_DEBUG_EVENT:
   case OUTPUT_DEBUG_STRING_EVENT:
     _state = kStopped;
-    _trap.event = StopInfo::kEventNone;
-    _trap.reason = StopInfo::kReasonNone;
+    _stopInfo.event = StopInfo::kEventNone;
+    _stopInfo.reason = StopInfo::kReasonNone;
     break;
 
   default:

--- a/Sources/Target/Windows/Thread.cpp
+++ b/Sources/Target/Windows/Thread.cpp
@@ -67,8 +67,8 @@ void Thread::updateState(DEBUG_EVENT const &de) {
   switch (de.dwDebugEventCode) {
   case EXCEPTION_DEBUG_EVENT:
     _state = kStopped;
-    _trap.event = StopInfo::kEventTrap;
-    _trap.reason = StopInfo::kReasonNone;
+    _trap.event = StopInfo::kEventStop;
+    _trap.reason = StopInfo::kReasonBreakpoint;
     break;
 
   case LOAD_DLL_DEBUG_EVENT: {

--- a/Sources/Target/Windows/X86/ProcessX86.cpp
+++ b/Sources/Target/Windows/X86/ProcessX86.cpp
@@ -8,6 +8,7 @@
 // PATENTS file in the same directory.
 //
 
+#include "DebugServer2/Architecture/X86/SoftwareBreakpointManager.h"
 #include "DebugServer2/Target/Process.h"
 
 using ds2::Architecture::GDBDescriptor;
@@ -16,6 +17,16 @@ using ds2::Architecture::LLDBDescriptor;
 namespace ds2 {
 namespace Target {
 namespace Windows {
+
+BreakpointManager *Process::breakpointManager() const {
+  if (_breakpointManager == nullptr) {
+    const_cast<Process *>(this)->_breakpointManager =
+        new Architecture::X86::SoftwareBreakpointManager(
+            reinterpret_cast<Target::Process *>(const_cast<Process *>(this)));
+  }
+
+  return _breakpointManager;
+}
 
 GDBDescriptor const *Process::getGDBRegistersDescriptor() const {
   return &Architecture::X86::GDB;


### PR DESCRIPTION
This will allow us to properly decode Windows StopInfo.