### PR TITLE
Add stubs for qModuleInfo.

### DIFF
--- a/Headers/DebugServer2/GDBRemote/DummySessionDelegateImpl.h
+++ b/Headers/DebugServer2/GDBRemote/DummySessionDelegateImpl.h
@@ -87,6 +87,10 @@ protected: // Debugging Session
                                           Address &data, bool &isSegment);
   virtual ErrorCode onQuerySharedLibrariesInfoAddress(Session &session,
                                                       Address &address);
+  virtual ErrorCode onQuerySharedLibraryInfo(Session &session,
+                                             std::string const &path,
+                                             std::string const &triple,
+                                             SharedLibraryInfo &info);
 
   virtual ErrorCode onRestart(Session &session, ProcessId pid);
   virtual ErrorCode onInterrupt(Session &session);

--- a/Headers/DebugServer2/GDBRemote/Session.h
+++ b/Headers/DebugServer2/GDBRemote/Session.h
@@ -139,6 +139,8 @@ private:
                              std::string const &);
   void Handle_qMemoryRegionInfo(ProtocolInterpreter::Handler const &,
                                 std::string const &);
+  void Handle_qModuleInfo(ProtocolInterpreter::Handler const &,
+                          std::string const &);
   void Handle_qOffsets(ProtocolInterpreter::Handler const &,
                        std::string const &);
   void Handle_qP(ProtocolInterpreter::Handler const &, std::string const &);

--- a/Headers/DebugServer2/GDBRemote/SessionDelegate.h
+++ b/Headers/DebugServer2/GDBRemote/SessionDelegate.h
@@ -93,6 +93,10 @@ protected: // Debugging Session
                                           Address &data, bool &isSegment) = 0;
   virtual ErrorCode onQuerySharedLibrariesInfoAddress(Session &session,
                                                       Address &address) = 0;
+  virtual ErrorCode onQuerySharedLibraryInfo(Session &session,
+                                             std::string const &path,
+                                             std::string const &triple,
+                                             SharedLibraryInfo &info) = 0;
 
   virtual ErrorCode onRestart(Session &session, ProcessId pid) = 0;
   virtual ErrorCode onInterrupt(Session &session) = 0;

--- a/Headers/DebugServer2/Target/POSIX/ELFProcess.h
+++ b/Headers/DebugServer2/Target/POSIX/ELFProcess.h
@@ -30,7 +30,7 @@ public:
 public:
   virtual ErrorCode getSharedLibraryInfoAddress(Address &address);
   virtual ErrorCode enumerateSharedLibraries(
-      std::function<void(SharedLibrary const &)> const &cb);
+      std::function<void(SharedLibraryInfo const &)> const &cb);
 
 public:
   virtual ErrorCode enumerateAuxiliaryVector(std::function<

--- a/Headers/DebugServer2/Target/ProcessBase.h
+++ b/Headers/DebugServer2/Target/ProcessBase.h
@@ -37,18 +37,6 @@ protected:
   ThreadBase::IdentityMap _threads;
   Thread *_currentThread;
 
-public:
-  struct SharedLibrary {
-    bool main;
-    std::string path;
-    struct {
-      uint64_t mapAddress;
-      uint64_t baseAddress;
-      uint64_t ldAddress;
-    } svr4;
-    std::vector<uint64_t> sections;
-  };
-
 protected:
   ProcessBase();
 

--- a/Headers/DebugServer2/Target/Windows/Process.h
+++ b/Headers/DebugServer2/Target/Windows/Process.h
@@ -95,7 +95,7 @@ public:
     return kErrorUnsupported;
   }
   virtual ErrorCode enumerateSharedLibraries(
-      std::function<void(SharedLibrary const &)> const &cb);
+      std::function<void(SharedLibraryInfo const &)> const &cb);
 
 public:
   virtual Architecture::GDBDescriptor const *getGDBRegistersDescriptor() const;

--- a/Headers/DebugServer2/Types.h
+++ b/Headers/DebugServer2/Types.h
@@ -297,6 +297,17 @@ struct MemoryRegionInfo {
     protection = 0;
   }
 };
+
+struct SharedLibraryInfo {
+  bool main;
+  std::string path;
+  struct {
+    uint64_t mapAddress;
+    uint64_t baseAddress;
+    uint64_t ldAddress;
+  } svr4;
+  std::vector<uint64_t> sections;
+};
 }
 
 #endif // !__DebugServer2_Types_h

--- a/Sources/GDBRemote/DummySessionDelegateImpl.cpp
+++ b/Sources/GDBRemote/DummySessionDelegateImpl.cpp
@@ -194,6 +194,12 @@ DummySessionDelegateImpl::onQuerySharedLibrariesInfoAddress(Session &,
   return kErrorUnsupported;
 }
 
+ErrorCode DummySessionDelegateImpl::onQuerySharedLibraryInfo(
+    Session &session, std::string const &path, std::string const &triple,
+    SharedLibraryInfo &info) {
+  return kErrorUnsupported;
+}
+
 ErrorCode DummySessionDelegateImpl::onRestart(Session &, ProcessId) {
   return kErrorUnsupported;
 }

--- a/Sources/GDBRemote/Session.cpp
+++ b/Sources/GDBRemote/Session.cpp
@@ -113,6 +113,7 @@ Session::Session(CompatibilityMode mode) : _compatMode(mode) {
   REGISTER_HANDLER_EQUALS_1(qLaunchGDBServer);
   REGISTER_HANDLER_EQUALS_1(qLaunchSuccess);
   REGISTER_HANDLER_EQUALS_1(qMemoryRegionInfo);
+  REGISTER_HANDLER_EQUALS_1(qModuleInfo);
   REGISTER_HANDLER_EQUALS_1(qOffsets);
   REGISTER_HANDLER_EQUALS_1(qP);
   REGISTER_HANDLER_EQUALS_1(qPlatform_IO_MkDir);
@@ -1815,6 +1816,30 @@ void Session::Handle_qMemoryRegionInfo(ProtocolInterpreter::Handler const &,
   }
 
   send(info.encode());
+}
+
+//
+// Packet:        qModuleInfo:<module_path>;<arch triple>
+// Description:   Get information for a module by given module path and
+//                architecture.
+// Compatibility: LLDB
+//
+void Session::Handle_qModuleInfo(ProtocolInterpreter::Handler const &,
+                                 std::string const &args) {
+  size_t semicolon = args.find(';');
+  std::string path(HexToString(args.substr(0, semicolon)));
+  std::string triple(HexToString(args.substr(semicolon + 1)));
+  SharedLibraryInfo info;
+
+  ErrorCode error =
+      _delegate->onQuerySharedLibraryInfo(*this, path, triple, info);
+  if (error != kSuccess) {
+    sendError(error);
+    return;
+  }
+
+  // FIXME: send the actual response.
+  sendOK();
 }
 
 //

--- a/Sources/Target/POSIX/ELFProcess.cpp
+++ b/Sources/Target/POSIX/ELFProcess.cpp
@@ -157,9 +157,9 @@ inline ErrorCode ReadELFLinkMap(ELFProcess *process, Address address,
 }
 
 template <typename T>
-ErrorCode EnumerateLinkMap(
-    ELFProcess *process, Address addressToDPtr,
-    std::function<void(ELFProcess::SharedLibrary const &)> const &cb) {
+ErrorCode
+EnumerateLinkMap(ELFProcess *process, Address addressToDPtr,
+                 std::function<void(SharedLibraryInfo const &)> const &cb) {
   ELFDebug<T> debug;
   ELFLinkMap<T> linkMap;
   T address;
@@ -188,7 +188,7 @@ ErrorCode EnumerateLinkMap(
     if (error != ds2::kSuccess)
       return error;
 
-    ELFProcess::SharedLibrary shlib;
+    SharedLibraryInfo shlib;
     shlib.main = isMain;
     shlib.sections.clear();
     shlib.svr4.mapAddress = linkMapAddress;
@@ -482,7 +482,7 @@ ErrorCode ELFProcess::getSharedLibraryInfoAddress(Address &address) {
 // Enumerates the linkmap of this SVR4 ELF process.
 //
 ErrorCode ELFProcess::enumerateSharedLibraries(
-    std::function<void(SharedLibrary const &)> const &cb) {
+    std::function<void(SharedLibraryInfo const &)> const &cb) {
   Address address;
   ErrorCode error = getSharedLibraryInfoAddress(address);
   if (error != kSuccess)

--- a/Sources/Target/Windows/Process.cpp
+++ b/Sources/Target/Windows/Process.cpp
@@ -271,7 +271,7 @@ ErrorCode Process::deallocateMemory(uint64_t address, size_t size) {
 }
 
 ErrorCode Process::enumerateSharedLibraries(
-    std::function<void(SharedLibrary const &)> const &cb) {
+    std::function<void(SharedLibraryInfo const &)> const &cb) {
   BOOL rc;
   std::vector<HMODULE> modules;
   DWORD bytesNeeded;
@@ -289,7 +289,7 @@ ErrorCode Process::enumerateSharedLibraries(
     return Platform::TranslateError();
 
   for (auto m : modules) {
-    SharedLibrary sl;
+    SharedLibraryInfo sl;
 
     sl.main = false;
 


### PR DESCRIPTION
I thought qModuleInfo was going to be required for Windows support, but we can probably do away without it. Still adding the current work I have so we have the stubs if we wanna implement it later on.