### PR TITLE
Handle Thread Exit Cleanly

### DIFF
--- a/Sources/Target/Linux/Thread.cpp
+++ b/Sources/Target/Linux/Thread.cpp
@@ -167,6 +167,13 @@ ErrorCode Thread::writeCPUState(Architecture::CPUState const &state) {
 ErrorCode Thread::updateStopInfo(int waitStatus) {
   super::updateStopInfo(waitStatus);
 
+  // First check to make sure the thread has not exited yet.
+  // If exited, return success early rather than updating the thread state.
+  if (_stopInfo.event == StopInfo::kEventExit) {
+    DS2ASSERT(_stopInfo.reason == StopInfo::kReasonNone);
+    return kSuccess;
+  }
+
   updateState();
 
   switch (_stopInfo.event) {


### PR DESCRIPTION
This change ensures ds2 handles thread exit cleanly.

Previously DS2 updates a thread and then checks for `_stopInfo.event`. This leads to a problem where a thread placeholder remains for too long and when `updateState()` invokes `ReadStat`, there is no such thread to be found in `/proc/...`. This change simply checks `_stopInfo.event` first and return early if the thread has already exited.