### PR TITLE
On Linux don't terminate process when detached

### DIFF
--- a/Sources/Target/Linux/Process.cpp
+++ b/Sources/Target/Linux/Process.cpp
@@ -41,7 +41,7 @@ Process::Process()
     : super(), _breakpointManager(nullptr), _watchpointManager(nullptr),
       _terminated(false) {}
 
-Process::~Process() { terminate(); }
+Process::~Process() {}
 
 ErrorCode Process::initialize(ProcessId pid, uint32_t flags) {
   //


### PR DESCRIPTION
Fixes #43,
When the Linux process (ds2/Sources/Target/Linux/Process.cpp) deallocates it calls terminate on the process even when ds2 doesn't own the process.

- Removes the call to terminate() in the destructor to fix this