### PR TITLE
Add ENDIAN defines in Base.h. Fixes issue 49.

### DIFF
--- a/Headers/DebugServer2/Architecture/ARM/CPUState.h
+++ b/Headers/DebugServer2/Architecture/ARM/CPUState.h
@@ -20,7 +20,7 @@ namespace Architecture {
 namespace ARM {
 
 struct VFPSingle {
-#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#ifdef ENDIAN_BIG
 uint32_t:
   32;
   uint32_t value;
@@ -36,7 +36,7 @@ struct VFPDouble {
 };
 
 struct VFPQuad {
-#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#ifdef ENDIAN_BIG
   uint64_t hi;
   uint64_t lo;
 #else

--- a/Headers/DebugServer2/Base.h
+++ b/Headers/DebugServer2/Base.h
@@ -41,6 +41,20 @@ typedef SSIZE_T ssize_t;
 #error "Target not supported."
 #endif
 
+#if defined(OS_WIN32)
+#define ENDIAN_LITTLE
+#else
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define ENDIAN_LITTLE
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#define ENDIAN_BIG
+#elif __BYTE_ORDER__ == __ORDER_PDP_ENDIAN__
+#define ENDIAN_MIDDLE
+#else
+#error "Unknown endianness"
+#endif
+#endif
+
 template <typename TYPE, size_t SIZE>
 static inline size_t array_size(TYPE const(&)[SIZE]) {
   return SIZE;

--- a/Headers/DebugServer2/Constants.h
+++ b/Headers/DebugServer2/Constants.h
@@ -54,11 +54,11 @@ enum Endian {
   kEndianBig = 1,
   kEndianLittle = 2,
   kEndianPDP = 3,
-#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#if defined(ENDIAN_BIG)
   kEndianNative = kEndianBig,
-#elif __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#elif defined(ENDIAN_LITTLE)
   kEndianNative = kEndianLittle,
-#elif __BYTE_ORDER__ == __ORDER_PDP_ENDIAN__
+#elif defined(ENDIAN_MIDDLE)
   kEndianNative = kEndianPDP,
 #else
   kEndianNative = kEndianUnknown,

--- a/Sources/Architecture/ARM/RegistersDescriptors.cpp
+++ b/Sources/Architecture/ARM/RegistersDescriptors.cpp
@@ -22,7 +22,7 @@ using ds2::Architecture::GDBFeature;
 using ds2::Architecture::GDBFeatureEntry;
 using ds2::Architecture::LLDBRegisterSet;
 
-#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#if defined(ENDIAN_BIG)
 #define REG_REL_OFFSET(MAXBYTES, RELOFF, REGSIZE) ((MAXBYTES) - ((RELOFF) + (REGSIZE))
 #else
 #define REG_REL_OFFSET(MAXBYTES, RELOFF, REGSIZE) (RELOFF)

--- a/Sources/Architecture/ARM64/RegistersDescriptors.cpp
+++ b/Sources/Architecture/ARM64/RegistersDescriptors.cpp
@@ -22,7 +22,7 @@ using ds2::Architecture::GDBFeature;
 using ds2::Architecture::GDBFeatureEntry;
 using ds2::Architecture::LLDBRegisterSet;
 
-#if defined(__BIG_ENDIAN__)
+#if defined(ENDIAN_BIG)
 #define REG_REL_OFFSET(MAXBYTES, RELOFF, REGSIZE) ((MAXBYTES) - ((RELOFF) + (REGSIZE))
 #else
 #define REG_REL_OFFSET(MAXBYTES, RELOFF, REGSIZE) (RELOFF)

--- a/Sources/Architecture/X86/RegistersDescriptors.cpp
+++ b/Sources/Architecture/X86/RegistersDescriptors.cpp
@@ -22,14 +22,14 @@ using ds2::Architecture::GDBFeature;
 using ds2::Architecture::GDBFeatureEntry;
 using ds2::Architecture::LLDBRegisterSet;
 
-#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-#define REG_REL_OFFSET(MAXBYTES, RELOFF, REGSIZE)                              \
-  ((MAXBYTES) - ((RELOFF) + (REGSIZE)))
+#if defined(ENDIAN_BIG)
+#define REG_REL_OFFSET(MAXBYTES, RELOFF, REGSIZE) ((MAXBYTES) - ((RELOFF) + (REGSIZE))
 #else
 #define REG_REL_OFFSET(MAXBYTES, RELOFF, REGSIZE) (RELOFF)
 #endif
 
 namespace {
+
 //
 // Register Definitions (Forward Declarations)
 //

--- a/Sources/Architecture/X86_64/RegistersDescriptors.cpp
+++ b/Sources/Architecture/X86_64/RegistersDescriptors.cpp
@@ -22,14 +22,14 @@ using ds2::Architecture::GDBFeature;
 using ds2::Architecture::GDBFeatureEntry;
 using ds2::Architecture::LLDBRegisterSet;
 
-#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-#define REG_REL_OFFSET(MAXBYTES, RELOFF, REGSIZE)                              \
-  ((MAXBYTES) - ((RELOFF) + (REGSIZE)))
+#if defined(ENDIAN_BIG)
+#define REG_REL_OFFSET(MAXBYTES, RELOFF, REGSIZE) ((MAXBYTES) - ((RELOFF) + (REGSIZE))
 #else
 #define REG_REL_OFFSET(MAXBYTES, RELOFF, REGSIZE) (RELOFF)
 #endif
 
 namespace {
+
 //
 // Register Definitions (Forward Declarations)
 //

--- a/Sources/GDBRemote/Structures.cpp
+++ b/Sources/GDBRemote/Structures.cpp
@@ -238,7 +238,7 @@ std::string StopCode::encodeRegisters() const {
     size_t regsize = regval.second.size << 3;
 
     ss << HEX(2) << (regval.first & 0xff) << ':' << HEX(regsize >> 2)
-#if defined(__BIG_ENDIAN__)
+#if defined(ENDIAN_BIG)
        << regval.second.value
 #else
        << (Swap64(regval.second.value) >> (64 - regsize))

--- a/Sources/Host/POSIX/Platform.cpp
+++ b/Sources/Host/POSIX/Platform.cpp
@@ -104,11 +104,11 @@ end:
 }
 
 ds2::Endian Platform::GetEndian() {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#if defined(ENDIAN_LITTLE)
   return kEndianLittle;
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#elif defined(ENDIAN_LITTLE)
   return kEndianBig;
-#elif __BYTE_ORDER__ == __ORDER_PDP_ENDIAN__
+#elif defined(ENDIAN_MIDDLE)
   return kEndianPDP;
 #else
   return kEndianUnknown;

--- a/Sources/Host/Windows/Platform.cpp
+++ b/Sources/Host/Windows/Platform.cpp
@@ -63,11 +63,11 @@ ds2::CPUSubType Platform::GetCPUSubType() {
 }
 
 ds2::Endian Platform::GetEndian() {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#if defined(ENDIAN_LITTLE)
   return kEndianLittle;
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#elif defined(ENDIAN_BIG)
   return kEndianBig;
-#elif __BYTE_ORDER__ == __ORDER_PDP_ENDIAN__
+#elif defined(ENDIAN_MIDDLE)
   return kEndianPDP;
 #else
   return kEndianUnknown;

--- a/Tools/main.cpp
+++ b/Tools/main.cpp
@@ -455,7 +455,7 @@ static void GenerateProlog1(FILE *fp, Context const &ctx) {
   fprintf(fp, "using ds2::Architecture::GDBFeatureEntry;\n");
   fprintf(fp, "using ds2::Architecture::LLDBRegisterSet;\n\n");
 
-  fprintf(fp, "#if defined(__BIG_ENDIAN__)\n");
+  fprintf(fp, "#if defined(ENDIAN_BIG)\n");
   fprintf(fp, "#define REG_REL_OFFSET(MAXBYTES, RELOFF, REGSIZE) ((MAXBYTES) - "
               "((RELOFF) + (REGSIZE))\n");
   fprintf(fp, "#else\n");


### PR DESCRIPTION
It turns out that __BYTE_ORDER__ and friends are not defined
by MSVC.  This lead to a bug, because expressions like
  #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
would evaluate as true, regardless of actual endianness.

With this change we stop using the aforementioned endianness
defines on Windows, and instead simply assume little endian.

This seems to be a safe assumption for modern Windows platforms.