### PR TITLE
Separate remote protocol logs from debug logs

### DIFF
--- a/Headers/DebugServer2/Utils/Log.h
+++ b/Headers/DebugServer2/Utils/Log.h
@@ -25,6 +25,7 @@ namespace ds2 {
 // Log Level
 //
 enum {
+  kLogLevelPacket,
   kLogLevelDebug,
   kLogLevelInfo,
   kLogLevelWarning,

--- a/Main/main.cpp
+++ b/Main/main.cpp
@@ -262,7 +262,9 @@ int main(int argc, char **argv) {
   opts.addOption(ds2::OptParse::stringOption, "log-output", 'o',
                  "output log message to the file specified");
   opts.addOption(ds2::OptParse::boolOption, "debug-remote", 'R',
-                 "enable debugging of remote protocol");
+                 "enable log for remote protocol packets");
+  opts.addOption(ds2::OptParse::boolOption, "debug", 'd',
+                 "enable debug log output");
   opts.addOption(ds2::OptParse::boolOption, "no-colors", 'n',
                  "disable colored output");
   opts.addOption(ds2::OptParse::boolOption, "keep-alive", 'k',
@@ -325,6 +327,8 @@ int main(int argc, char **argv) {
   }
 
   if (opts.getBool("debug-remote")) {
+    ds2::SetLogLevel(ds2::kLogLevelPacket);
+  } else if (opts.getBool("debug")) {
     ds2::SetLogLevel(ds2::kLogLevelDebug);
   }
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ ds2 accepts the following options:
 ```
 usage: ds2 [OPTIONS] [PROGRAM [ARGUMENTS...]]
   -a, --attach ARG          attach to the name or PID specified
-  -R, --debug-remote        enable debugging of remote protocol
+  -R, --debug-remote        enable remote packet log output
+  -d, --debug               enable debug output
   -k, --keep-alive          keep the server alive after the client disconnects
   -L, --list-processes      list processes debuggable by the current user
   -l, --lldb-compat         force ds2 to run in lldb compat mode

--- a/Sources/GDBRemote/ProtocolInterpreter.cpp
+++ b/Sources/GDBRemote/ProtocolInterpreter.cpp
@@ -43,7 +43,7 @@ static std::string EscapeForTerm(std::string const &s) {
 ProtocolInterpreter::ProtocolInterpreter() : _session(nullptr) {}
 
 void ProtocolInterpreter::onPacketData(std::string const &data, bool valid) {
-  DS2LOG(Debug, "getpkt(\"%s\")", EscapeForTerm(&data[0]).c_str());
+  DS2LOG(Packet, "getpkt(\"%s\")", EscapeForTerm(&data[0]).c_str());
 
   if (_session == nullptr)
     return;
@@ -151,7 +151,7 @@ void ProtocolInterpreter::onCommand(std::string const &command,
   size_t commandLength;
   Handler const *handler = findHandler(command, commandLength);
   if (handler == nullptr) {
-    DS2LOG(Debug, "handler for command '%s' unknown", command.c_str());
+    DS2LOG(Packet, "handler for command '%s' unknown", command.c_str());
 
     //
     // The handler couldn't be found, send a NAK.
@@ -172,11 +172,11 @@ void ProtocolInterpreter::onCommand(std::string const &command,
 
   if (extra.find_first_of("*}") != std::string::npos) {
     extra = Uncompress(extra);
-    DS2LOG(Debug, "args='%.*s'", static_cast<int>(extra.length()), &extra[0]);
+    DS2LOG(Packet, "args='%.*s'", static_cast<int>(extra.length()), &extra[0]);
   }
 
 #if 0
-    DS2LOG(Debug, "command='%s' arguments='%s'\n",
+    DS2LOG(Packet, "command='%s' arguments='%s'\n",
             command.substr(0, commandLength).c_str(),
             extra.c_str());
 #endif

--- a/Sources/GDBRemote/SessionBase.cpp
+++ b/Sources/GDBRemote/SessionBase.cpp
@@ -97,7 +97,7 @@ bool SessionBase::send(std::string const &data, bool escaped) {
      << (unsigned)csum;
 
   std::string final_data = ss.str();
-  DS2LOG(Debug, "putpkt(\"%s\", %u)", final_data.c_str(),
+  DS2LOG(Packet, "putpkt(\"%s\", %u)", final_data.c_str(),
          (unsigned)final_data.length());
 
   return _channel->send(final_data);

--- a/Sources/Utils/Log.cpp
+++ b/Sources/Utils/Log.cpp
@@ -93,6 +93,9 @@ void vLog(int level, char const *classname, char const *funcname,
     color = "\x1b[1;36m";
     label = "DEBUG  ";
     break;
+  case kLogLevelPacket:
+    color = "\x1b[0;35m";
+    label = "PACKET  ";
   default:
     break;
   }


### PR DESCRIPTION
You can now run ds2 with -R to see remote protocol packet dumps,
and -V to see just debug logs.