### PR TITLE
Implement qMemoryRegionInfo packet handling

### DIFF
--- a/Headers/DebugServer2/GDBRemote/DebugSessionImpl.h
+++ b/Headers/DebugServer2/GDBRemote/DebugSessionImpl.h
@@ -119,6 +119,10 @@ protected:
   virtual ErrorCode onDeallocateMemory(Session &session,
                                        Address const &address);
 
+  virtual ErrorCode onQueryMemoryRegionInfo(Session &session,
+                                            Address const &address,
+                                            MemoryRegionInfo &info);
+
 protected:
   virtual ErrorCode onSetProgramArguments(Session &session,
                                           StringCollection const &args);

--- a/Sources/GDBRemote/DebugSessionImpl.cpp
+++ b/Sources/GDBRemote/DebugSessionImpl.cpp
@@ -745,6 +745,15 @@ ErrorCode DebugSessionImpl::onDeallocateMemory(Session &,
   return kSuccess;
 }
 
+ErrorCode DebugSessionImpl::onQueryMemoryRegionInfo(Session &,
+                                                    Address const &addr,
+                                                    MemoryRegionInfo &info) {
+  if (_process == nullptr)
+    return kErrorProcessNotFound;
+  else
+    return _process->getMemoryRegionInfo(addr, info);
+}
+
 ErrorCode
 DebugSessionImpl::onSetProgramArguments(Session &,
                                         StringCollection const &args) {


### PR DESCRIPTION
This packet provides lldb with information about a memory region.