### PR TITLE
Fix memory read error in EnumerateLinkMap

### DIFF
--- a/Sources/Target/POSIX/ELFProcess.cpp
+++ b/Sources/Target/POSIX/ELFProcess.cpp
@@ -201,8 +201,13 @@ EnumerateLinkMap(ELFProcess *process, Address addressToDPtr,
     shlib.svr4.baseAddress = linkMap.baseAddress;
     shlib.svr4.ldAddress = linkMap.ldAddress;
 
-    error = process->readMemory(linkMap.nameAddress, nameBuffer, PATH_MAX);
-    if (error != ds2::kSuccess)
+    size_t nread = 0;
+    error =
+        process->readMemory(linkMap.nameAddress, nameBuffer, PATH_MAX, &nread);
+    if (error != ds2::kSuccess && nread == 0)
+      return error;
+
+    if (strnlen(nameBuffer, nread) == nread)
       return error;
 
     shlib.path = nameBuffer;


### PR DESCRIPTION
Currently, the PATH_MAX read will always go out of bounds and fail,
and no shared libraries will be found. Instead of requiring a
successful read of PATH_MAX bytes, accept a successful read of
any number of bytes.

Fixes enumerateSharedLibraries.