### PR TITLE
Get rid of uses of wait4.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,7 +218,7 @@ set_property(TARGET ds2 PROPERTY CXX_STANDARD 11)
 
 if ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux" OR "${CMAKE_SYSTEM_NAME}" MATCHES "FreeBSD")
   include(CheckFunctionExists)
-  foreach (FUNC gettid personality posix_openpt wait4)
+  foreach (FUNC gettid personality posix_openpt)
     string(TOUPPER "${FUNC}" UCFUNC)
     CHECK_FUNCTION_EXISTS(${FUNC} HAVE_${UCFUNC})
     if (HAVE_${UCFUNC})

--- a/Headers/DebugServer2/Host/Linux/ExtraWrappers.h
+++ b/Headers/DebugServer2/Host/Linux/ExtraWrappers.h
@@ -51,13 +51,6 @@ static inline int tkill(pid_t tid, int signo) {
   return ::syscall(__NR_tkill, tid, signo);
 }
 
-#if !defined(HAVE_WAIT4)
-static inline pid_t wait4(pid_t pid, int *stat_loc, int options,
-                          struct rusage *rusage) {
-  return ::syscall(__NR_wait4, pid, stat_loc, options, rusage);
-}
-#endif
-
 // We use ds2_snprintf and ds2_vsnprintf in ds2 code to make sure we don't use
 // the bogus vsnprintf provided in the MSVC runtime. The following two defines
 // allow us to avoid #ifdef conditionals accross the code.

--- a/Headers/DebugServer2/Host/POSIX/AsyncProcessWaiter.h
+++ b/Headers/DebugServer2/Host/POSIX/AsyncProcessWaiter.h
@@ -30,7 +30,6 @@ private:
   struct Event {
     ProcessId pid;
     int status;
-    struct rusage ru;
   };
 
   typedef std::map<ProcessId, Event> EventsMap;
@@ -50,10 +49,8 @@ public:
 
 public:
   bool wait(std::set<ProcessId> const &pids, ProcessId &wpid, int &status,
-            struct rusage &ru, bool hang);
-
-  bool wait(ProcessId const &pid, ProcessId &wpid, int &status,
-            struct rusage &ru, bool hang);
+            bool hang);
+  bool wait(ProcessId const &pid, ProcessId &wpid, int &status, bool hang);
 
 private:
   void start();

--- a/Sources/Host/FreeBSD/PTrace.cpp
+++ b/Sources/Host/FreeBSD/PTrace.cpp
@@ -13,7 +13,6 @@
 
 #include "DebugServer2/Host/FreeBSD/PTrace.h"
 #include "DebugServer2/Host/Platform.h"
-#include "DebugServer2/Host/POSIX/AsyncProcessWaiter.h"
 #include "DebugServer2/Utils/Log.h"
 
 #include <cerrno>

--- a/Sources/Host/Linux/PTrace.cpp
+++ b/Sources/Host/Linux/PTrace.cpp
@@ -12,7 +12,6 @@
 
 #include "DebugServer2/Host/Linux/ExtraWrappers.h"
 #include "DebugServer2/Host/Linux/PTrace.h"
-#include "DebugServer2/Host/POSIX/AsyncProcessWaiter.h"
 #include "DebugServer2/Host/Platform.h"
 #include "DebugServer2/Utils/Log.h"
 
@@ -21,6 +20,7 @@
 #include <cstdio>
 #include <limits>
 #include <sys/ptrace.h>
+#include <sys/wait.h>
 
 #define super ds2::Host::POSIX::PTrace
 
@@ -46,8 +46,7 @@ ErrorCode PTrace::wait(ProcessThreadId const &ptid, bool hang, int *status) {
 
   int stat;
   pid_t ret;
-  struct rusage ru;
-  ret = wait4(pid, &stat, __WALL | (hang ? 0 : WNOHANG), &ru);
+  ret = waitpid(pid, &stat, __WALL | (hang ? 0 : WNOHANG));
   if (ret < 0)
     return kErrorProcessNotFound;
   DS2ASSERT(!hang || ret == pid);

--- a/Sources/Host/POSIX/AsyncProcessWaiter.cpp
+++ b/Sources/Host/POSIX/AsyncProcessWaiter.cpp
@@ -32,17 +32,17 @@ AsyncProcessWaiter &AsyncProcessWaiter::Instance() {
 }
 
 bool AsyncProcessWaiter::wait(ProcessId const &pid, ProcessId &wpid,
-                              int &status, struct rusage &ru, bool hang) {
+                              int &status, bool hang) {
   if (pid <= 0)
     return false;
 
   std::set<ProcessId> pids;
   pids.insert(pid);
-  return wait(pids, wpid, status, ru, hang);
+  return wait(pids, wpid, status, hang);
 }
 
 bool AsyncProcessWaiter::wait(std::set<ProcessId> const &pids, ProcessId &wpid,
-                              int &status, struct rusage &ru, bool hang) {
+                              int &status, bool hang) {
   if (pids.empty())
     return false;
 
@@ -55,7 +55,6 @@ bool AsyncProcessWaiter::wait(std::set<ProcessId> const &pids, ProcessId &wpid,
       if (it != _events.end()) {
         wpid = it->second.pid;
         status = it->second.status;
-        ru = it->second.ru;
         _events.erase(it);
         return true;
       }
@@ -78,7 +77,7 @@ void AsyncProcessWaiter::run() {
   for (;;) {
     Event event;
 
-    pid_t pid = ::wait4(-1, &event.status, DEFAULT_WAIT_FLAGS, &event.ru);
+    pid_t pid = ::waitpid(-1, &event.status, DEFAULT_WAIT_FLAGS);
     if (pid < 0)
       break;
 


### PR DESCRIPTION
We can use waitpid instead, which seems to be easier to find on some
sysroots, and provides the functionality of wait4 minus rusage (which we
never used).