### PR TITLE
Stop sending success responses for qSymbol

### DIFF
--- a/Sources/GDBRemote/DummySessionDelegateImpl.cpp
+++ b/Sources/GDBRemote/DummySessionDelegateImpl.cpp
@@ -140,7 +140,7 @@ ErrorCode DummySessionDelegateImpl::onQuerySymbol(Session &,
                                                   std::string const &,
                                                   std::string const &,
                                                   std::string &) {
-  return kSuccess;
+  return kErrorUnsupported;
 }
 
 ErrorCode DummySessionDelegateImpl::onQueryRegisterInfo(Session &, uint32_t,


### PR DESCRIPTION
DS2 doesn't support this packet, but was sending responses
indicating that it does.