### PR TITLE
Directly link against liblog on android.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,8 +250,9 @@ endif ()
 add_subdirectory(Tools/JSObjects "${CMAKE_CURRENT_BINARY_DIR}/JSObjects")
 target_link_libraries(ds2 jsobjects)
 
-if ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
-  target_link_libraries(ds2 dl)
+if (${ENABLE_LOGCAT})
+  target_link_libraries(ds2 log)
+  target_compile_definitions(ds2 PRIVATE ENABLE_LOGCAT)
 endif ()
 
 if ("${CMAKE_SYSTEM_NAME}" MATCHES "FreeBSD")

--- a/Sources/Utils/Log.cpp
+++ b/Sources/Utils/Log.cpp
@@ -19,8 +19,8 @@
 #include "DebugServer2/Host/FreeBSD/ExtraWrappers.h"
 #endif
 
-#if defined(__ANDROID__)
-#include <dlfcn.h>
+#if defined(ENABLE_LOGCAT)
+#include <android/log.h>
 #endif
 #include <sstream>
 
@@ -37,9 +37,7 @@ FILE *sOutputStream = stderr;
 #endif
 }
 
-#if defined(__ANDROID__)
-#include <android/log.h>
-
+#if defined(ENABLE_LOGCAT)
 static void androidLogcat(int level, char const *functag, char const *message) {
   android_LogPriority androidLevel;
 
@@ -59,16 +57,7 @@ static void androidLogcat(int level, char const *functag, char const *message) {
     DS2_UNREACHABLE();
   }
 
-  static void *const androidLogLib = dlopen("liblog.so", RTLD_LAZY);
-  if (androidLogLib == nullptr)
-    return;
-  static auto *const androidLogFunc =
-      reinterpret_cast<decltype(&__android_log_print)>(
-          dlsym(androidLogLib, "__android_log_print"));
-  if (androidLogFunc == nullptr)
-    return;
-
-  androidLogFunc(androidLevel, "ds2", "[%s] %s", functag, message);
+  __android_log_print(androidLevel, "ds2", "[%s] %s", functag, message);
 }
 #endif
 
@@ -106,7 +95,7 @@ void vLog(int level, char const *classname, char const *funcname,
     functag << classname << "::";
   functag << funcname;
 
-#if defined(__ANDROID__)
+#if defined(ENABLE_LOGCAT)
   // If we're on Android pollute logcat as well.
   androidLogcat(level, functag.str().c_str(), buffer.data());
 #endif

--- a/Support/CMake/Toolchain-Android-ARM.cmake
+++ b/Support/CMake/Toolchain-Android-ARM.cmake
@@ -15,3 +15,4 @@ set(CMAKE_C_COMPILER /tmp/aosp-toolchain/arm-linux-androideabi-4.9/bin/arm-linux
 set(CMAKE_CXX_COMPILER /tmp/aosp-toolchain/arm-linux-androideabi-4.9/bin/arm-linux-androideabi-g++)
 
 set(PIE 1)
+set(ENABLE_LOGCAT 1)

--- a/Support/CMake/Toolchain-Android-ARM64.cmake
+++ b/Support/CMake/Toolchain-Android-ARM64.cmake
@@ -15,3 +15,4 @@ set(CMAKE_C_COMPILER /tmp/aosp-toolchain/aarch64-linux-android-4.9/bin/aarch64-l
 set(CMAKE_CXX_COMPILER /tmp/aosp-toolchain/aarch64-linux-android-4.9/bin/aarch64-linux-android-g++)
 
 set(PIE 1)
+set(ENABLE_LOGCAT 1)

--- a/Support/CMake/Toolchain-Android-X86.cmake
+++ b/Support/CMake/Toolchain-Android-X86.cmake
@@ -15,3 +15,4 @@ set(CMAKE_C_COMPILER /tmp/aosp-toolchain/x86_64-linux-android-4.9/bin/x86_64-lin
 set(CMAKE_CXX_COMPILER /tmp/aosp-toolchain/x86_64-linux-android-4.9/bin/x86_64-linux-android-g++)
 
 set(PIE 1)
+set(ENABLE_LOGCAT 1)

--- a/Support/CMake/Toolchain-Android-X86_64.cmake
+++ b/Support/CMake/Toolchain-Android-X86_64.cmake
@@ -15,3 +15,4 @@ set(CMAKE_C_COMPILER /tmp/aosp-toolchain/x86_64-linux-android-4.9/bin/x86_64-lin
 set(CMAKE_CXX_COMPILER /tmp/aosp-toolchain/x86_64-linux-android-4.9/bin/x86_64-linux-android-g++)
 
 set(PIE 1)
+set(ENABLE_LOGCAT 1)

--- a/Support/CMake/Toolchain-Tizen-ARM.cmake
+++ b/Support/CMake/Toolchain-Tizen-ARM.cmake
@@ -1,0 +1,17 @@
+##
+## Copyright (c) 2014, Facebook, Inc.
+## All rights reserved.
+##
+## This source code is licensed under the University of Illinois/NCSA Open
+## Source License found in the LICENSE file in the root directory of this
+## source tree. An additional grant of patent rights can be found in the
+## PATENTS file in the same directory.
+##
+
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR ARM)
+
+set(CMAKE_C_COMPILER arm-linux-gnueabi-gcc-4.7)
+set(CMAKE_CXX_COMPILER arm-linux-gnueabi-g++-4.7)
+
+set(STATIC 1)

--- a/Support/CMake/Toolchain-Tizen-X86.cmake
+++ b/Support/CMake/Toolchain-Tizen-X86.cmake
@@ -1,0 +1,17 @@
+##
+## Copyright (c) 2014, Facebook, Inc.
+## All rights reserved.
+##
+## This source code is licensed under the University of Illinois/NCSA Open
+## Source License found in the LICENSE file in the root directory of this
+## source tree. An additional grant of patent rights can be found in the
+## PATENTS file in the same directory.
+##
+
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR X86)
+
+set(CMAKE_C_COMPILER gcc-4.8)
+set(CMAKE_CXX_COMPILER g++-4.8)
+
+set(STATIC 1)


### PR DESCRIPTION
The dlopen stuff is usless as the binaries generated with the android
toolchain won't run on other systems anyway.