### PR TITLE
[WIP] Don't re-define user_fpxregs_struct on android-x86

### DIFF
--- a/Headers/DebugServer2/Host/Linux/ExtraWrappers.h
+++ b/Headers/DebugServer2/Host/Linux/ExtraWrappers.h
@@ -22,7 +22,7 @@
 #include <sys/syscall.h>
 #include <unistd.h>
 
-#if defined(ARCH_X86) && defined(__ANDROID__)
+#if defined(ARCH_X86_64) && defined(__ANDROID__)
 #include <sys/user.h>
 typedef struct user_fxsr_struct user_fpxregs_struct;
 #endif


### PR DESCRIPTION
defined in sys/user.h