### PR TITLE
Fix compilation with user_fpxregs_struct on android-x86

### DIFF
--- a/Headers/DebugServer2/Host/Linux/ExtraWrappers.h
+++ b/Headers/DebugServer2/Host/Linux/ExtraWrappers.h
@@ -24,7 +24,6 @@
 
 #if defined(ARCH_X86) && defined(__ANDROID__)
 #include <sys/user.h>
-typedef struct user_fxsr_struct user_fpxregs_struct;
 #endif
 
 #if !defined(HAVE_GETTID)

--- a/Sources/Host/Linux/X86_64/PTraceX86_64.cpp
+++ b/Sources/Host/Linux/X86_64/PTraceX86_64.cpp
@@ -19,10 +19,6 @@
 
 #define super ds2::Host::POSIX::PTrace
 
-#if defined(__ANDROID__)
-#define mxcr_mask mxcsr_mask
-#endif
-
 namespace ds2 {
 namespace Host {
 namespace Linux {


### PR DESCRIPTION
I think the aosp toolchain changed, because sys/user.h now defines this struct.