### PR TITLE
Prevent android logging from overflowing logcat buffer

### DIFF
--- a/Sources/Utils/Log.cpp
+++ b/Sources/Utils/Log.cpp
@@ -57,7 +57,10 @@ static void androidLogcat(int level, char const *functag, char const *message) {
     DS2_UNREACHABLE();
   }
 
-  __android_log_print(androidLevel, "ds2", "[%s] %s", functag, message);
+  std::stringstream ss(message);
+  std::string line;
+  while (std::getline(ss, line, '\n'))
+    __android_log_print(androidLevel, "ds2", "[%s] %s", functag, line.c_str());
 }
 #endif
 


### PR DESCRIPTION
From android/log.h:

"Log message text may be truncated to less than an implementation-specific
limit (e.g. 1023 characters max)."

Since logcat appends newline characters to the buffer anyway,
split the message string on newlines to prevent awkwardly-split string.