### PR TITLE
Fix process termination with kill packet on Windows

### DIFF
--- a/Headers/DebugServer2/GDBRemote/Types.h
+++ b/Headers/DebugServer2/GDBRemote/Types.h
@@ -36,9 +36,7 @@ struct StopCode {
   enum Event {
     kSignal,
     kCleanExit,
-#if !defined(OS_WIN32)
     kSignalExit,
-#endif
   };
 
   Event event;

--- a/Sources/GDBRemote/DebugSessionImpl.cpp
+++ b/Sources/GDBRemote/DebugSessionImpl.cpp
@@ -176,8 +176,17 @@ ErrorCode DebugSessionImpl::queryStopCode(Session &session,
                                           StopCode &stop) const {
   Thread *thread = findThread(ptid);
   DS2LOG(Debug, "thread %p", thread);
-  if (thread == nullptr)
+  if (thread == nullptr) {
+#if defined(OS_WIN32)
+    if (_process && !_process->isAlive()) {
+      stop.event = StopCode::kSignalExit;
+      stop.signal = 9;
+      return kSuccess;
+    }
+#else
     return kErrorProcessNotFound;
+#endif
+  }
 
   bool readRegisters = true;
   StopInfo const &info = thread->stopInfo();

--- a/Sources/GDBRemote/Structures.cpp
+++ b/Sources/GDBRemote/Structures.cpp
@@ -358,11 +358,9 @@ std::string StopCode::encode(CompatibilityMode mode) const {
     ss << DEC;
     break;
 
-#if !defined(OS_WIN32)
   case kSignalExit:
     ss << 'X' << HEX(2) << (signal & 0xff) << DEC;
     break;
-#endif
 
   case kCleanExit:
     ss << 'W' << HEX(2) << (status & 0xff) << DEC;

--- a/Sources/Target/Windows/Process.cpp
+++ b/Sources/Target/Windows/Process.cpp
@@ -53,7 +53,18 @@ ErrorCode Process::initialize(ProcessId pid, HANDLE handle, ThreadId tid,
 
 ErrorCode Process::attach(bool reattach) { return kErrorUnsupported; }
 
-ErrorCode Process::detach() { return kErrorUnsupported; }
+ErrorCode Process::detach() {
+  prepareForDetach();
+
+  BOOL result = DebugActiveProcessStop(_pid);
+  if (!result)
+    return Platform::TranslateError();
+
+  cleanup();
+  _flags &= ~kFlagAttachedProcess;
+
+  return kSuccess;
+}
 
 ErrorCode Process::terminate() {
   BOOL result = TerminateProcess(_handle, 0);

--- a/Sources/Target/Windows/Process.cpp
+++ b/Sources/Target/Windows/Process.cpp
@@ -72,12 +72,15 @@ ErrorCode Process::terminate() {
     return Platform::TranslateError();
 
   _terminated = true;
-  return kSuccess;
+  return detach();
 }
 
 bool Process::isAlive() const { return !_terminated; }
 
 ErrorCode Process::wait(int *status, bool hang) {
+  if (_terminated)
+    return kSuccess;
+
   DEBUG_EVENT de;
   bool keepGoing = true;
 


### PR DESCRIPTION
We need ds2 to detach from the process before the process can finish terminating. This causes some complications in how we encode stop info, so that has been updated as well.