### PR TITLE
Enable interrupt packet handling on windows

### DIFF
--- a/Headers/DebugServer2/Target/Windows/Process.h
+++ b/Headers/DebugServer2/Target/Windows/Process.h
@@ -42,7 +42,7 @@ public:
   virtual ErrorCode detach();
 
 public:
-  virtual ErrorCode interrupt() { return kErrorUnsupported; }
+  virtual ErrorCode interrupt();
   virtual ErrorCode terminate();
   virtual bool isAlive() const;
 

--- a/Sources/Target/Windows/Process.cpp
+++ b/Sources/Target/Windows/Process.cpp
@@ -66,6 +66,14 @@ ErrorCode Process::detach() {
   return kSuccess;
 }
 
+ErrorCode Process::interrupt() {
+  BOOL result = DebugBreakProcess(_handle);
+  if (!result)
+    return Platform::TranslateError();
+
+  return kSuccess;
+}
+
 ErrorCode Process::terminate() {
   BOOL result = TerminateProcess(_handle, 0);
   if (!result)


### PR DESCRIPTION
Allows ds2 to kill processes that are not already stopped.