### PR TITLE
Always build all the linux syscall wrappers as weak.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,7 @@ set(HOST_POSIX_SOURCES
 
 set(HOST_Linux_SOURCES
     ${HOST_POSIX_SOURCES}
+    Sources/Host/Linux/ExtraWrappers.cpp
     Sources/Host/Linux/ProcFS.cpp
     Sources/Host/Linux/Platform.cpp
     Sources/Host/Linux/PTrace.cpp
@@ -218,15 +219,6 @@ target_include_directories(ds2 PUBLIC Headers)
 set_property(TARGET ds2 PROPERTY CXX_STANDARD 11)
 
 if ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux" OR "${CMAKE_SYSTEM_NAME}" MATCHES "FreeBSD")
-  include(CheckFunctionExists)
-  foreach (FUNC gettid personality posix_openpt)
-    string(TOUPPER "${FUNC}" UCFUNC)
-    CHECK_FUNCTION_EXISTS(${FUNC} HAVE_${UCFUNC})
-    if (HAVE_${UCFUNC})
-      target_compile_definitions(ds2 PRIVATE HAVE_${UCFUNC})
-    endif ()
-  endforeach ()
-
   include(CheckIncludeFile)
   CHECK_INCLUDE_FILE(sys/personality.h HAVE_SYS_PERSONALITY_H)
   if (HAVE_SYS_PERSONALITY_H)

--- a/Headers/DebugServer2/Host/Linux/ExtraWrappers.h
+++ b/Headers/DebugServer2/Host/Linux/ExtraWrappers.h
@@ -11,6 +11,8 @@
 #ifndef __DebugServer2_Host_Linux_ExtraWrappers_h
 #define __DebugServer2_Host_Linux_ExtraWrappers_h
 
+#include "DebugServer2/Utils/CompilerSupport.h"
+
 #include <fcntl.h>
 // Older android native sysroots don't have sys/personality.h.
 #if defined(HAVE_SYS_PERSONALITY_H)
@@ -19,36 +21,26 @@
 #include <linux/personality.h>
 #undef personality
 #endif
-#include <sys/syscall.h>
 #include <unistd.h>
 
 #if defined(ARCH_X86) && defined(__ANDROID__)
 #include <sys/user.h>
 #endif
 
-#if !defined(HAVE_GETTID)
-static inline pid_t gettid() { return ::syscall(__NR_gettid); }
-#endif
+extern "C" {
 
-#if !defined(HAVE_PERSONALITY)
-static inline int personality(unsigned long persona) {
-  return ::syscall(__NR_personality, persona);
-}
-#endif
+pid_t gettid() DS2_ATTRIBUTE_WEAK;
 
-#if !defined(HAVE_POSIX_OPENPT)
-static inline int posix_openpt(int flags) { return ::open("/dev/ptmx", flags); }
-#endif
+int personality(unsigned long persona) DS2_ATTRIBUTE_WEAK;
+
+// Older android native sysroots don't have posix_openpt.
+int posix_openpt(int flags) DS2_ATTRIBUTE_WEAK;
 
 // No glibc wrapper for tgkill
-static inline int tgkill(pid_t pid, pid_t tid, int signo) {
-  return ::syscall(__NR_tgkill, pid, tid, signo);
-}
+int tgkill(pid_t pid, pid_t tid, int signo) DS2_ATTRIBUTE_WEAK;
 
 // No glibc wrapper for tkill
-static inline int tkill(pid_t tid, int signo) {
-  return ::syscall(__NR_tkill, tid, signo);
-}
+int tkill(pid_t tid, int signo) DS2_ATTRIBUTE_WEAK;
 
 // We use ds2_snprintf and ds2_vsnprintf in ds2 code to make sure we don't use
 // the bogus vsnprintf provided in the MSVC runtime. The following two defines
@@ -56,5 +48,6 @@ static inline int tkill(pid_t tid, int signo) {
 // See Headers/DebugServer2/Host/Windows/ExtraWrappers.h.
 #define ds2_snprintf snprintf
 #define ds2_vsnprintf vsnprintf
+}
 
 #endif // !__DebugServer2_Host_Linux_ExtraWrappers_h

--- a/Headers/DebugServer2/Utils/CompilerSupport.h
+++ b/Headers/DebugServer2/Utils/CompilerSupport.h
@@ -30,6 +30,12 @@
 #define DS2_ATTRIBUTE_PRINTF(FORMAT, START)
 #endif
 
+#if __has_attribute(weak)
+#define DS2_ATTRIBUTE_WEAK __attribute__((__weak__))
+#else
+#define DS2_ATTRIBUTE_WEAK
+#endif
+
 #if !defined(__clang__) && defined(_MSC_VER)
 #define DS2_UNREACHABLE() __assume(0)
 #elif __has_builtin(__builtin_unreachable) || __GNUC_PREREQ(4, 5)

--- a/Sources/Host/Linux/ExtraWrappers.cpp
+++ b/Sources/Host/Linux/ExtraWrappers.cpp
@@ -1,0 +1,31 @@
+//
+// Copyright (c) 2014, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the University of Illinois/NCSA Open
+// Source License found in the LICENSE file in the root directory of this
+// source tree. An additional grant of patent rights can be found in the
+// PATENTS file in the same directory.
+//
+
+#include "DebugServer2/Host/Linux/ExtraWrappers.h"
+
+#include <cstdio>
+#include <sys/syscall.h>
+
+extern "C" {
+
+int posix_openpt(int flags) { return ::open("/dev/ptmx", flags); }
+
+int personality(unsigned long persona) {
+  return ::syscall(__NR_personality, persona);
+}
+
+pid_t gettid() { return ::syscall(__NR_gettid); }
+
+int tgkill(pid_t pid, pid_t tid, int signo) {
+  return ::syscall(__NR_tgkill, pid, tid, signo);
+}
+
+int tkill(pid_t tid, int signo) { return ::syscall(__NR_tkill, tid, signo); }
+}


### PR DESCRIPTION
This help prevents issues with ds2 being built with a certain sysroot
(that has some functions) and then run on a device with an older OS
versions that doesn't have these symbols.