### PR TITLE
Include jstopinfo in qThreadStopInfo

### DIFF
--- a/Headers/DebugServer2/GDBRemote/DebugSessionImpl.h
+++ b/Headers/DebugServer2/GDBRemote/DebugSessionImpl.h
@@ -155,6 +155,12 @@ protected:
   ErrorCode queryStopCode(Session &session, ProcessThreadId const &ptid,
                           StopCode &stop) const;
 
+protected:
+  ErrorCode fetchStopInfoForAllThreads(Session &session,
+                                       std::vector<StopCode> &stops,
+                                       StopCode &processStop);
+  ErrorCode createThreadsStopInfo(Session &session, JSArray &threadsStopInfo);
+
 private:
   ErrorCode spawnProcess(StringCollection const &args,
                          EnvironmentBlock const &env);

--- a/Headers/DebugServer2/GDBRemote/DummySessionDelegateImpl.h
+++ b/Headers/DebugServer2/GDBRemote/DummySessionDelegateImpl.h
@@ -188,6 +188,11 @@ protected: // Debugging Session
   ErrorCode onXferWrite(Session &session, std::string const &object,
                         std::string const &annex, uint64_t offset,
                         std::string const &buffer, size_t &nwritten) override;
+  ErrorCode fetchStopInfoForAllThreads(Session &session,
+                                       std::vector<StopCode> &stops,
+                                       StopCode &processStop) override;
+  ErrorCode createThreadsStopInfo(Session &session,
+                                  JSArray &threadsStopInfo) override;
 
 protected: // Platform Session
   ErrorCode onDisableASLR(Session &session, bool disable) override;

--- a/Headers/DebugServer2/GDBRemote/SessionDelegate.h
+++ b/Headers/DebugServer2/GDBRemote/SessionDelegate.h
@@ -208,6 +208,11 @@ protected: // Debugging Session
                                 std::string const &annex, uint64_t offset,
                                 std::string const &buffer,
                                 size_t &nwritten) = 0;
+  virtual ErrorCode fetchStopInfoForAllThreads(Session &session,
+                                               std::vector<StopCode> &stops,
+                                               StopCode &processStop) = 0;
+  virtual ErrorCode createThreadsStopInfo(Session &session,
+                                          JSArray &threadsStopInfo) = 0;
 
 protected: // Platform Session
   virtual ErrorCode onDisableASLR(Session &session, bool disable) = 0;

--- a/Headers/DebugServer2/GDBRemote/Types.h
+++ b/Headers/DebugServer2/GDBRemote/Types.h
@@ -58,7 +58,10 @@ public:
 
 public:
   std::string encode(CompatibilityMode mode) const;
+  std::string encodeWithAllThreads(CompatibilityMode mode,
+                                   const JSArray &threadsStopInfo) const;
   JSDictionary *encodeJson() const;
+  JSDictionary *encodeBriefJson() const;
 
 private:
   std::string reasonToString() const;

--- a/Sources/GDBRemote/DummySessionDelegateImpl.cpp
+++ b/Sources/GDBRemote/DummySessionDelegateImpl.cpp
@@ -569,5 +569,16 @@ ErrorCode DummySessionDelegateImpl::onFlashWrite(Session &, Address const &,
 ErrorCode DummySessionDelegateImpl::onFlashDone(Session &) {
   return kErrorUnsupported;
 }
+
+ErrorCode DummySessionDelegateImpl::fetchStopInfoForAllThreads(
+    Session &session, std::vector<StopCode> &stops, StopCode &processStop) {
+  return kErrorUnsupported;
+}
+
+ErrorCode
+DummySessionDelegateImpl::createThreadsStopInfo(Session &session,
+                                                JSArray &threadsStopInfo) {
+  return kErrorUnsupported;
+}
 }
 }


### PR DESCRIPTION
Add the jstopinfo field to the qThreadStopInfo response.

It's a json object with the hex tid of each thread along with its stop reason. Handle_jThreadsInfo also fetches the information of all threads, so I refactored this logic out into a new function. It's appended as
 
```
jstopinfo:[{... json object...}];
```

I also refactored the encoding method for StopCode. There's a new method encodeWithJStopInfo that appends the jstopinfo to the stream generated by the generic encoder. I'm tempted to move the encoding logic to a new class, but I don't know if that makes a lot of sense.

I tested it by stopping a multi-threaded dummy program with a breakpoint. The log of the packets related to qThreadStopInfo showed:

```
<  23> send packet: $qThreadStopInfo13e4#f8
< 561> read packet: $T00thread:13e4;name:a.out;core:0;threads:13e4,13f1;00:00feffffffffffff;01..lots of numbers...;;17:00000000;jstopinfo:[{"tid":"13e4","reason":"none"}],{"tid":"13f1","reason":"breakpoint"}]];#f8

```
where the suffix contains the jstopinfo.