### PR TITLE
Add MinGW builds to travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ env:
   - TARGET="Linux-ARM"
   - TARGET="Linux-X86"
   - TARGET="Linux-X86_64"
+  - TARGET="MinGW-X86"
   - TARGET="Tizen-ARM"
   - TARGET="Tizen-X86"
 ############################

--- a/Support/Testing/Travis/install.py
+++ b/Support/Testing/Travis/install.py
@@ -43,6 +43,8 @@ elif target in linux_packages:
         packages.append(linux_packages[target])
         if os.getenv('CLANG') == '1':
             packages.append('clang-3.7')
+elif target == 'MinGW-X86':
+    packages.append('g++-mingw-w64-i686')
 elif target in android_toolchains:
     # Android builds get the toolchain from AOSP.
     check_call('./Support/Scripts/prepare-android-toolchain.sh "%s"' % android_toolchains[target], shell=True)


### PR DESCRIPTION
We don't ship MinGW binaries for Windows, but this offers some coverage
for Windows builds as Travis doesn't support Windows + VS.