### PR TITLE
Use getpeer name on client sockets.

### DIFF
--- a/Headers/DebugServer2/Host/Linux/PTrace.h
+++ b/Headers/DebugServer2/Host/Linux/PTrace.h
@@ -102,7 +102,7 @@ protected:
     typedef enum __ptrace_request ptrace_request_t;
 #endif
     DS2LOG(Debug, "running ptrace command %s on pid %d",
-           Stringify::Ptrace(request, false), pid);
+           Stringify::Ptrace(request), pid);
     return ::ptrace(static_cast<ptrace_request_t>(request), pid,
                     (void *)(uintptr_t)addr, (void *)(uintptr_t)data);
   }

--- a/Headers/DebugServer2/Host/Socket.h
+++ b/Headers/DebugServer2/Host/Socket.h
@@ -15,6 +15,8 @@
 
 #if defined(OS_WIN32)
 #include <winsock2.h>
+#elif defined(OS_LINUX) || defined(OS_FREEBSD)
+#include <sys/socket.h>
 #endif
 
 namespace ds2 {
@@ -62,6 +64,9 @@ public:
   inline bool listen(std::string const &port) { return listen(nullptr, port); }
   Socket *accept();
   bool connect(std::string const &host, std::string const &port);
+
+protected:
+  bool getSocketInfo(struct sockaddr_storage *ss) const;
 
 public:
   std::string address() const;

--- a/Headers/DebugServer2/Support/POSIX/Stringify.h
+++ b/Headers/DebugServer2/Support/POSIX/Stringify.h
@@ -21,10 +21,10 @@ namespace POSIX {
 
 class Stringify {
 public:
-  static char const *Signal(int signal, bool dieOnFail = true);
-  static char const *SignalCode(int signal, int code, bool dieOnFail = true);
-  static char const *Errno(int error, bool dieOnFail = true);
-  static char const *Ptrace(int code, bool dieOnFail = true);
+  static char const *Signal(int signal);
+  static char const *SignalCode(int signal, int code);
+  static char const *Errno(int error);
+  static char const *Ptrace(int code);
 };
 }
 }

--- a/Headers/DebugServer2/Support/Stringify.h
+++ b/Headers/DebugServer2/Support/Stringify.h
@@ -35,7 +35,7 @@ class Stringify
 #endif
 {
 public:
-  static char const *Error(ErrorCode error, bool dieOnFail = true);
+  static char const *Error(ErrorCode error);
 };
 }
 }

--- a/Headers/DebugServer2/Support/StringifyPrivate.h
+++ b/Headers/DebugServer2/Support/StringifyPrivate.h
@@ -1,0 +1,25 @@
+//
+// Copyright (c) 2014-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the University of Illinois/NCSA Open
+// Source License found in the LICENSE file in the root directory of this
+// source tree. An additional grant of patent rights can be found in the
+// PATENTS file in the same directory.
+//
+
+#ifndef __DebugServer2_Support_StringifyPrivate_h
+#define __DebugServer2_Support_StringifyPrivate_h
+
+#define DO_STRINGIFY(VALUE)                                                    \
+  case VALUE:                                                                  \
+    return #VALUE;
+
+#define DO_DEFAULT(MESSAGE, VALUE)                                             \
+  default:                                                                     \
+    if (dieOnFail)                                                             \
+      DS2BUG(MESSAGE ": %#x", VALUE);                                          \
+    else                                                                       \
+      return nullptr;
+
+#endif // !__DebugServer2_Support_StringifyPrivate_h

--- a/Headers/DebugServer2/Support/StringifyPrivate.h
+++ b/Headers/DebugServer2/Support/StringifyPrivate.h
@@ -17,9 +17,6 @@
 
 #define DO_DEFAULT(MESSAGE, VALUE)                                             \
   default:                                                                     \
-    if (dieOnFail)                                                             \
-      DS2BUG(MESSAGE ": %#x", VALUE);                                          \
-    else                                                                       \
-      return nullptr;
+    DS2BUG(MESSAGE ": %#x", VALUE);
 
 #endif // !__DebugServer2_Support_StringifyPrivate_h

--- a/Headers/DebugServer2/Support/StringifyPrivate.h
+++ b/Headers/DebugServer2/Support/StringifyPrivate.h
@@ -17,6 +17,11 @@
 
 #define DO_DEFAULT(MESSAGE, VALUE)                                             \
   default:                                                                     \
-    DS2BUG(MESSAGE ": %#x", VALUE);
+    do {                                                                       \
+      DS2LOG(Warning, MESSAGE ": %#lx", (unsigned long)VALUE);                 \
+      static thread_local char tmp[20];                                        \
+      ::snprintf(tmp, sizeof(tmp), "%#lx", (unsigned long)VALUE);              \
+      return tmp;                                                              \
+    } while (0);
 
 #endif // !__DebugServer2_Support_StringifyPrivate_h

--- a/Headers/DebugServer2/Support/Windows/Stringify.h
+++ b/Headers/DebugServer2/Support/Windows/Stringify.h
@@ -23,7 +23,7 @@ namespace Windows {
 
 class Stringify {
 public:
-  static char const *ExceptionCode(DWORD code, bool dieOnFail = true);
+  static char const *ExceptionCode(DWORD code);
 };
 }
 }

--- a/README.md
+++ b/README.md
@@ -129,9 +129,9 @@ dependencies.
 
 ### Cross compiling for Linux-ARM
 
-Cross-compiling for Linux-ARM is also possible. On Ubuntu 14.04, install
-`gcc-4.7-arm-linux-gnueabi` and `g++-4.7-arm-linux-gnueabi` and use the
-provided toolchain file.
+Cross-compiling for Linux-ARM is also possible. On Ubuntu 14.04, install an arm
+toolchain (for instance `g++-4.8-arm-linux-gnueabihf`) and use the provided
+toolchain file.
 
 ```sh
 cd ds2

--- a/Sources/Host/Common/Socket.cpp
+++ b/Sources/Host/Common/Socket.cpp
@@ -319,10 +319,10 @@ std::string Socket::address() const {
     return std::string();
   }
 
+  auto func = listening() ? ::getsockname : ::getpeername;
   struct sockaddr_storage ss;
   socklen_t sslen = sizeof(ss);
-  if (::getsockname(_handle, reinterpret_cast<struct sockaddr *>(&ss), &sslen) <
-      0) {
+  if (func(_handle, reinterpret_cast<struct sockaddr *>(&ss), &sslen) < 0) {
     return std::string();
   }
 
@@ -355,10 +355,10 @@ std::string Socket::port() const {
     return std::string();
   }
 
+  auto func = listening() ? ::getsockname : ::getpeername;
   struct sockaddr_storage ss;
   socklen_t sslen = sizeof(ss);
-  if (::getsockname(_handle, reinterpret_cast<struct sockaddr *>(&ss), &sslen) <
-      0) {
+  if (func(_handle, reinterpret_cast<struct sockaddr *>(&ss), &sslen) < 0) {
     return std::string();
   }
 

--- a/Sources/Host/Common/Socket.cpp
+++ b/Sources/Host/Common/Socket.cpp
@@ -326,28 +326,24 @@ std::string Socket::address() const {
     return std::string();
   }
 
-  std::string result;
-
   switch (ss.ss_family) {
   case AF_INET: {
     char addressStr[INET_ADDRSTRLEN];
     inet_ntop(AF_INET,
               &reinterpret_cast<struct sockaddr_in *>(&ss)->sin_addr.s_addr,
               addressStr, sizeof(addressStr));
-    result.assign(addressStr);
+    return addressStr;
   } break;
   case AF_INET6: {
     char addressStr[INET6_ADDRSTRLEN];
     inet_ntop(AF_INET6,
               &reinterpret_cast<struct sockaddr_in6 *>(&ss)->sin6_addr.s6_addr,
               addressStr, sizeof(addressStr));
-    result.assign(addressStr);
+    return addressStr;
   } break;
   default:
     DS2BUG("unknown socket family: %u", (unsigned int)ss.ss_family);
   }
-
-  return result;
 }
 
 std::string Socket::port() const {

--- a/Sources/Support/POSIX/Stringify.cpp
+++ b/Sources/Support/POSIX/Stringify.cpp
@@ -9,6 +9,7 @@
 //
 
 #include "DebugServer2/Support/Stringify.h"
+#include "DebugServer2/Support/StringifyPrivate.h"
 #include "DebugServer2/Utils/Log.h"
 
 #include <errno.h>
@@ -18,17 +19,6 @@
 namespace ds2 {
 namespace Support {
 namespace POSIX {
-
-#define DO_STRINGIFY(VALUE)                                                    \
-  case VALUE:                                                                  \
-    return #VALUE;
-
-#define DO_DEFAULT(MESSAGE, VALUE)                                             \
-  default:                                                                     \
-    if (dieOnFail)                                                             \
-      DS2BUG(MESSAGE ": %#x", VALUE);                                          \
-    else                                                                       \
-      return nullptr;
 
 char const *Stringify::Signal(int signal, bool dieOnFail) {
   // SIGRTMIN can expand to a glibc call (not usable in a switch statement), so

--- a/Sources/Support/POSIX/Stringify.cpp
+++ b/Sources/Support/POSIX/Stringify.cpp
@@ -20,7 +20,7 @@ namespace ds2 {
 namespace Support {
 namespace POSIX {
 
-char const *Stringify::Signal(int signal, bool dieOnFail) {
+char const *Stringify::Signal(int signal) {
   // SIGRTMIN can expand to a glibc call (not usable in a switch statement), so
   // check for it first.
   if (signal == SIGRTMIN)
@@ -64,7 +64,7 @@ char const *Stringify::Signal(int signal, bool dieOnFail) {
   }
 }
 
-char const *Stringify::SignalCode(int signal, int code, bool dieOnFail) {
+char const *Stringify::SignalCode(int signal, int code) {
   switch (signal) {
   case SIGILL:
     switch (code) {
@@ -98,7 +98,7 @@ char const *Stringify::SignalCode(int signal, int code, bool dieOnFail) {
   }
 }
 
-char const *Stringify::Errno(int error, bool dieOnFail) {
+char const *Stringify::Errno(int error) {
   switch (error) {
     DO_STRINGIFY(E2BIG)
     DO_STRINGIFY(EACCES)
@@ -237,7 +237,7 @@ char const *Stringify::Errno(int error, bool dieOnFail) {
   }
 }
 
-char const *Stringify::Ptrace(int code, bool dieOnFail) {
+char const *Stringify::Ptrace(int code) {
   switch (code) {
 #if defined(OS_LINUX)
     DO_STRINGIFY(PTRACE_ATTACH)

--- a/Sources/Support/Stringify.cpp
+++ b/Sources/Support/Stringify.cpp
@@ -15,7 +15,7 @@
 namespace ds2 {
 namespace Support {
 
-char const *Stringify::Error(ErrorCode error, bool dieOnFail) {
+char const *Stringify::Error(ErrorCode error) {
   switch (error) {
     DO_STRINGIFY(kSuccess)
     DO_STRINGIFY(kErrorNoPermission)

--- a/Sources/Support/Stringify.cpp
+++ b/Sources/Support/Stringify.cpp
@@ -9,21 +9,11 @@
 //
 
 #include "DebugServer2/Support/Stringify.h"
+#include "DebugServer2/Support/StringifyPrivate.h"
 #include "DebugServer2/Utils/Log.h"
 
 namespace ds2 {
 namespace Support {
-
-#define DO_STRINGIFY(VALUE)                                                    \
-  case VALUE:                                                                  \
-    return #VALUE;
-
-#define DO_DEFAULT(MESSAGE, VALUE)                                             \
-  default:                                                                     \
-    if (dieOnFail)                                                             \
-      DS2BUG(MESSAGE ": %#x", VALUE);                                          \
-    else                                                                       \
-      return nullptr;
 
 char const *Stringify::Error(ErrorCode error, bool dieOnFail) {
   switch (error) {

--- a/Sources/Support/Windows/Stringify.cpp
+++ b/Sources/Support/Windows/Stringify.cpp
@@ -16,7 +16,7 @@ namespace ds2 {
 namespace Support {
 namespace Windows {
 
-char const *Stringify::ExceptionCode(DWORD code, bool dieOnFail) {
+char const *Stringify::ExceptionCode(DWORD code) {
   switch (code) {
     DO_STRINGIFY(EXCEPTION_ACCESS_VIOLATION)
     DO_STRINGIFY(EXCEPTION_ARRAY_BOUNDS_EXCEEDED)

--- a/Sources/Support/Windows/Stringify.cpp
+++ b/Sources/Support/Windows/Stringify.cpp
@@ -9,22 +9,12 @@
 //
 
 #include "DebugServer2/Support/Stringify.h"
+#include "DebugServer2/Support/StringifyPrivate.h"
 #include "DebugServer2/Utils/Log.h"
 
 namespace ds2 {
 namespace Support {
 namespace Windows {
-
-#define DO_STRINGIFY(VALUE)                                                    \
-  case VALUE:                                                                  \
-    return #VALUE;
-
-#define DO_DEFAULT(MESSAGE, VALUE)                                             \
-  default:                                                                     \
-    if (dieOnFail)                                                             \
-      DS2BUG(MESSAGE ": %#lx", VALUE);                                         \
-    else                                                                       \
-      return nullptr;
 
 char const *Stringify::ExceptionCode(DWORD code, bool dieOnFail) {
   switch (code) {

--- a/Support/CMake/Toolchain-Linux-ARM.cmake
+++ b/Support/CMake/Toolchain-Linux-ARM.cmake
@@ -11,5 +11,5 @@
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR ARM)
 
-set(CMAKE_C_COMPILER arm-linux-gnueabi-gcc-4.7)
-set(CMAKE_CXX_COMPILER arm-linux-gnueabi-g++-4.7)
+set(CMAKE_C_COMPILER arm-linux-gnueabihf-gcc-4.8)
+set(CMAKE_CXX_COMPILER arm-linux-gnueabihf-g++-4.8)

--- a/Support/Testing/Travis/install.py
+++ b/Support/Testing/Travis/install.py
@@ -14,7 +14,7 @@ from subprocess import check_call
 
 packages = []
 
-linux_packages = { 'Linux-ARM':     'g++-4.7-arm-linux-gnueabi',
+linux_packages = { 'Linux-ARM':     'g++-4.8-arm-linux-gnueabihf',
                    'Linux-X86':     'g++-5-multilib',
                    'Linux-X86_64':  'g++-5' }
 


### PR DESCRIPTION
This is important so we display the right information during
reverse-connect.