### PR TITLE
Fix FreeBSD build

### DIFF
--- a/Sources/Target/FreeBSD/Process.cpp
+++ b/Sources/Target/FreeBSD/Process.cpp
@@ -48,7 +48,7 @@ ErrorCode Process::initialize(ProcessId pid, uint32_t flags) {
   // Wait the main thread.
   //
   int status;
-  ErrorCode error = ptrace().wait(pid, true, &status);
+  ErrorCode error = ptrace().wait(pid, &status);
   DS2LOG(Debug, "wait result=%d", error);
   if (error != kSuccess)
     return error;
@@ -73,7 +73,7 @@ ErrorCode Process::attach(int waitStatus) {
 
     _flags |= kFlagAttachedProcess;
 
-    error = ptrace().wait(_pid, true, &waitStatus);
+    error = ptrace().wait(_pid, &waitStatus);
     if (error != kSuccess)
       return error;
     ptrace().traceThat(_pid);
@@ -107,7 +107,7 @@ ErrorCode Process::attach(int waitStatus) {
         if (ptrace().attach(tid) == kSuccess) {
           int status;
 
-          ptrace().wait(tid, true, &status);
+          ptrace().wait(tid, &status);
           _ptrace.getLwpInfo(tid, &lwpinfo);
           ptrace().traceThat(tid);
           thread->updateStopInfo(status);
@@ -144,7 +144,7 @@ continue_waiting:
   DS2LOG(Debug, "stopped: status=%d", status);
 
   if (WIFEXITED(status)) {
-    err = super::wait(&status, true);
+    err = super::wait(&status);
     DS2LOG(Debug, "exited: status=%d", status);
     _currentThread->updateStopInfo(status);
     _terminated = true;
@@ -199,7 +199,7 @@ continue_waiting:
         if (ptrace().attach(tid) == kSuccess) {
           int status;
 
-          ptrace().wait(tid, true, &status);
+          ptrace().wait(tid, &status);
           _ptrace.getLwpInfo(tid, &lwpinfo);
           ptrace().traceThat(tid);
           thread->updateStopInfo(status);

--- a/Sources/Target/FreeBSD/Thread.cpp
+++ b/Sources/Target/FreeBSD/Thread.cpp
@@ -57,7 +57,7 @@ ErrorCode Thread::suspend() {
 
     int status;
     error = process()->ptrace().wait(ProcessThreadId(process()->pid(), tid()),
-                                     true, &status);
+                                     &status);
     if (error != kSuccess) {
       DS2LOG(Error, "failed to wait for tid %d, error=%s\n", tid(),
              strerror(errno));

--- a/Sources/Target/POSIX/ELFProcess.cpp
+++ b/Sources/Target/POSIX/ELFProcess.cpp
@@ -296,11 +296,15 @@ ErrorCode ELFProcess::updateInfo() {
     // Query the memory region information to know where
     // is the load base.
     MemoryRegionInfo mri;
+#if defined(OS_LINUX)
+    // C++ doesn't allow an initialization between a goto and the label
     MemoryRegionInfo prevMri;
+#endif
     error = getMemoryRegionInfo(_entryPoint, mri);
     if (error != kSuccess)
       goto mri_error;
 
+#if defined(OS_LINUX)
     // For some reason, on Android 5.1 and up some ELF segments get loaded in
     // memory multiple smaller contiguous regions instead of being loaded as a
     // single big mapping.
@@ -320,6 +324,9 @@ ErrorCode ELFProcess::updateInfo() {
              mri.backingFileOffset + mri.length == prevMri.backingFileOffset);
 
     _loadBase = prevMri.start;
+#else
+    _loadBase = mri.start;
+#endif
 
   mri_error:
     // Restore the hack.


### PR DESCRIPTION
2 fixes:
 - Disable linux specific feature in elf's code https://github.com/facebook/ds2/commit/a5bcf6f62704adf4f03c012605e5f84ad8c9e820
    * For this fix I try to stay as close as possible to the code before the faulty commit, the only difference is we will set back the _hack_ after getting the MemoryInfo.
 - Remove hang usage in all the call to Process::wait https://github.com/facebook/ds2/commit/02aa8b1970bae5ae58d50c0f4a719a51d132b328

test lldb on MacOSX, ds2 on freebsd
```bash
bash-3.2$ lldb a.out 
(lldb) target create "a.out"
Current executable set to 'a.out' (x86_64).
(lldb) gdb-remote xx.xx.xx.159:4242
Process 98820 stopped
* thread #1: tid = 0x1884d, 0x0000000800602420, name = 'a.out', stop reason = signal SIGTRAP
    frame #0: 0x0000000800602420
->  0x800602420: xorq   %rbp, %rbp
    0x800602423: subq   $0x18, %rsp
    0x800602427: movq   %rdi, %r12
    0x80060242a: movq   %rsp, %rsi
(lldb) c
Process 98820 resuming
Process 98820 exited with status = 0 (0x00000000) 
(lldb)  
```