### PR TITLE
Revert "Re-enable Concurrent tests which no longer hang"

### DIFF
--- a/Support/Testing/Patches/Disable-broken-Concurrent-tests.patch
+++ b/Support/Testing/Patches/Disable-broken-Concurrent-tests.patch
@@ -6,7 +6,7 @@ index f0f2c3f..231b20c 100644
      #
      @unittest2.skipIf(TestBase.skipLongRunningTest(), "Skip this long running test")
      @dwarf_test
-+    @unittest2.expectedFailure
++    @skipIfLinux
      def test_many_breakpoints_dwarf(self):
          """Test 100 breakpoints from 100 threads."""
          self.buildDwarf(dictionary=self.getBuildFlags())
@@ -14,7 +14,7 @@ index f0f2c3f..231b20c 100644
  
      @unittest2.skipIf(TestBase.skipLongRunningTest(), "Skip this long running test")
      @dwarf_test
-+    @unittest2.expectedFailure
++    @skipIfLinux
      def test_many_watchpoints_dwarf(self):
          """Test 100 watchpoints from 100 threads."""
          self.buildDwarf(dictionary=self.getBuildFlags())
@@ -22,7 +22,7 @@ index f0f2c3f..231b20c 100644
  
      @unittest2.skipIf(TestBase.skipLongRunningTest(), "Skip this long running test")
      @dwarf_test
-+    @unittest2.expectedFailure
++    @skipIfLinux
      def test_many_signals_dwarf(self):
          """Test 100 signals from 100 threads."""
          self.buildDwarf(dictionary=self.getBuildFlags())
@@ -30,7 +30,7 @@ index f0f2c3f..231b20c 100644
  
      @unittest2.skipIf(TestBase.skipLongRunningTest(), "Skip this long running test")
      @dwarf_test
-+    @unittest2.expectedFailure
++    @skipIfLinux
      def test_many_crash_dwarf(self):
          """Test 100 threads that cause a segfault."""
          self.buildDwarf(dictionary=self.getBuildFlags())
@@ -38,15 +38,31 @@ index f0f2c3f..231b20c 100644
      #
      @dwarf_test
      @skipIfFreeBSD # timing out on buildbot
-+    @unittest2.expectedFailure
++    @skipIfLinux
      def test_signal_break_dwarf(self):
          """Test signal and a breakpoint in multiple threads."""
+         self.buildDwarf(dictionary=self.getBuildFlags())
+@@ -65,6 +70,7 @@ class ConcurrentEventsTestCase(TestBase):
+ 
+     @dwarf_test
+     @skipIfFreeBSD # timing out on buildbot
++    @skipIfLinux
+     def test_delay_signal_break_dwarf(self):
+         """Test (1-second delay) signal and a breakpoint in multiple threads."""
+         self.buildDwarf(dictionary=self.getBuildFlags())
+@@ -72,6 +78,7 @@ class ConcurrentEventsTestCase(TestBase):
+ 
+     @dwarf_test
+     @skipIfFreeBSD # timing out on buildbot
++    @skipIfLinux
+     def test_signal_delay_break_dwarf(self):
+         """Test signal and a (1 second delay) breakpoint in multiple threads."""
          self.buildDwarf(dictionary=self.getBuildFlags())
 @@ -84,6 +91,7 @@ class ConcurrentEventsTestCase(TestBase):
      @dwarf_test
      @skipIfFreeBSD # timing out on buildbot
      @skipIfRemoteDueToDeadlock
-+    @unittest2.expectedFailure
++    @skipIfLinux
      def test_watch_break_dwarf(self):
          """Test watchpoint and a breakpoint in multiple threads."""
          self.buildDwarf(dictionary=self.getBuildFlags())
@@ -54,7 +70,7 @@ index f0f2c3f..231b20c 100644
      @dwarf_test
      @skipIfFreeBSD # timing out on buildbot
      @skipIfRemoteDueToDeadlock
-+    @unittest2.expectedFailure
++    @skipIfLinux
      def test_delay_watch_break_dwarf(self):
          """Test (1-second delay) watchpoint and a breakpoint in multiple threads."""
          self.buildDwarf(dictionary=self.getBuildFlags())
@@ -62,7 +78,7 @@ index f0f2c3f..231b20c 100644
      @dwarf_test
      @skipIfFreeBSD # timing out on buildbot
      @skipIfRemoteDueToDeadlock
-+    @unittest2.expectedFailure
++    @skipIfLinux
      def test_watch_break_dwarf_delay(self):
          """Test watchpoint and a (1 second delay) breakpoint in multiple threads."""
          self.buildDwarf(dictionary=self.getBuildFlags())
@@ -70,7 +86,7 @@ index f0f2c3f..231b20c 100644
      @dwarf_test
      @skipIfFreeBSD # timing out on buildbot
      @skipIfRemoteDueToDeadlock
-+    @unittest2.expectedFailure
++    @skipIfLinux
      def test_signal_watch_dwarf(self):
          """Test a watchpoint and a signal in multiple threads."""
          self.buildDwarf(dictionary=self.getBuildFlags())
@@ -78,7 +94,7 @@ index f0f2c3f..231b20c 100644
      @dwarf_test
      @skipIfFreeBSD # timing out on buildbot
      @skipIfRemoteDueToDeadlock
-+    @unittest2.expectedFailure
++    @skipIfLinux
      def test_delay_signal_watch_dwarf(self):
          """Test a watchpoint and a (1 second delay) signal in multiple threads."""
          self.buildDwarf(dictionary=self.getBuildFlags())
@@ -95,15 +111,23 @@ index f0f2c3f..231b20c 100644
      #
      @dwarf_test
      @skipIfFreeBSD # timing out on buildbot
-+    @unittest2.expectedFailure
++    @skipIfLinux
      def test_two_breakpoint_threads_dwarf(self):
          """Test two threads that trigger a breakpoint. """
+         self.buildDwarf(dictionary=self.getBuildFlags())
+@@ -146,6 +159,7 @@ class ConcurrentEventsTestCase(TestBase):
+ 
+     @dwarf_test
+     @skipIfFreeBSD # timing out on buildbot
++    @skipIfLinux
+     def test_breakpoint_one_delay_breakpoint_threads_dwarf(self):
+         """Test threads that trigger a breakpoint where one thread has a 1 second delay. """
          self.buildDwarf(dictionary=self.getBuildFlags())
 @@ -154,6 +168,7 @@ class ConcurrentEventsTestCase(TestBase):
  
      @dwarf_test
      @skipIfFreeBSD # timing out on buildbot
-+    @unittest2.expectedFailure
++    @skipIfLinux
      def test_two_breakpoints_one_signal_dwarf(self):
          """Test two threads that trigger a breakpoint and one signal thread. """
          self.buildDwarf(dictionary=self.getBuildFlags())
@@ -111,7 +135,7 @@ index f0f2c3f..231b20c 100644
  
      @dwarf_test
      @skipIfFreeBSD # timing out on buildbot
-+    @unittest2.expectedFailure
++    @skipIfLinux
      def test_breakpoint_delay_breakpoint_one_signal_dwarf(self):
          """Test two threads that trigger a breakpoint (one with a 1 second delay) and one signal thread. """
          self.buildDwarf(dictionary=self.getBuildFlags())
@@ -119,7 +143,7 @@ index f0f2c3f..231b20c 100644
  
      @dwarf_test
      @skipIfFreeBSD # timing out on buildbot
-+    @unittest2.expectedFailure
++    @skipIfLinux
      def test_two_breakpoints_one_delay_signal_dwarf(self):
          """Test two threads that trigger a breakpoint and one (1 second delay) signal thread. """
          self.buildDwarf(dictionary=self.getBuildFlags())
@@ -127,7 +151,7 @@ index f0f2c3f..231b20c 100644
      @dwarf_test
      @skipIfFreeBSD # timing out on buildbot
      @skipIfRemoteDueToDeadlock
-+    @unittest2.expectedFailure
++    @skipIfLinux
      def test_two_breakpoints_one_watchpoint_dwarf(self):
          """Test two threads that trigger a breakpoint and one watchpoint thread. """
          self.buildDwarf(dictionary=self.getBuildFlags())
@@ -135,7 +159,7 @@ index f0f2c3f..231b20c 100644
      @dwarf_test
      @skipIfFreeBSD # timing out on buildbot
      @skipIfRemoteDueToDeadlock
-+    @unittest2.expectedFailure
++    @skipIfLinux
      def test_breakpoints_delayed_breakpoint_one_watchpoint_dwarf(self):
          """Test a breakpoint, a delayed breakpoint, and one watchpoint thread. """
          self.buildDwarf(dictionary=self.getBuildFlags())
@@ -143,7 +167,7 @@ index f0f2c3f..231b20c 100644
      @dwarf_test
      @skipIfFreeBSD # timing out on buildbot
      @skipIfRemoteDueToDeadlock
-+    @unittest2.expectedFailure
++    @skipIfLinux
      def test_two_watchpoint_threads_dwarf(self):
          """Test two threads that trigger a watchpoint. """
          self.buildDwarf(dictionary=self.getBuildFlags())
@@ -151,7 +175,7 @@ index f0f2c3f..231b20c 100644
      @dwarf_test
      @skipIfFreeBSD # timing out on buildbot
      @skipIfRemoteDueToDeadlock
-+    @unittest2.expectedFailure
++    @skipIfLinux
      def test_watchpoint_with_delay_watchpoint_threads_dwarf(self):
          """Test two threads that trigger a watchpoint where one thread has a 1 second delay. """
          self.buildDwarf(dictionary=self.getBuildFlags())
@@ -159,7 +183,7 @@ index f0f2c3f..231b20c 100644
      @dwarf_test
      @skipIfFreeBSD # timing out on buildbot
      @skipIfRemoteDueToDeadlock
-+    @unittest2.expectedFailure
++    @skipIfLinux
      def test_two_watchpoints_one_breakpoint_dwarf(self):
          """Test two threads that trigger a watchpoint and one breakpoint thread. """
          self.buildDwarf(dictionary=self.getBuildFlags())
@@ -167,7 +191,7 @@ index f0f2c3f..231b20c 100644
      @dwarf_test
      @skipIfFreeBSD # timing out on buildbot
      @skipIfRemoteDueToDeadlock
-+    @unittest2.expectedFailure
++    @skipIfLinux
      def test_two_watchpoints_one_delay_breakpoint_dwarf(self):
          """Test two threads that trigger a watchpoint and one (1 second delay) breakpoint thread. """
          self.buildDwarf(dictionary=self.getBuildFlags())
@@ -175,7 +199,7 @@ index f0f2c3f..231b20c 100644
      @dwarf_test
      @skipIfFreeBSD # timing out on buildbot
      @skipIfRemoteDueToDeadlock
-+    @unittest2.expectedFailure
++    @skipIfLinux
      def test_watchpoint_delay_watchpoint_one_breakpoint_dwarf(self):
          """Test two threads that trigger a watchpoint (one with a 1 second delay) and one breakpoint thread. """
          self.buildDwarf(dictionary=self.getBuildFlags())
@@ -183,7 +207,7 @@ index f0f2c3f..231b20c 100644
      @dwarf_test
      @skipIfFreeBSD # timing out on buildbot
      @skipIfRemoteDueToDeadlock
-+    @unittest2.expectedFailure
++    @skipIfLinux
      def test_two_watchpoints_one_signal_dwarf(self):
          """Test two threads that trigger a watchpoint and one signal thread. """
          self.buildDwarf(dictionary=self.getBuildFlags())
@@ -191,7 +215,7 @@ index f0f2c3f..231b20c 100644
      @dwarf_test
      @skipIfFreeBSD # timing out on buildbot
      @skipIfRemoteDueToDeadlock
-+    @unittest2.expectedFailure
++    @skipIfLinux
      def test_signal_watch_break_dwarf(self):
          """Test a signal/watchpoint/breakpoint in multiple threads."""
          self.buildDwarf(dictionary=self.getBuildFlags())
@@ -199,7 +223,7 @@ index f0f2c3f..231b20c 100644
      @dwarf_test
      @skipIfFreeBSD # timing out on buildbot
      @skipIfRemoteDueToDeadlock
-+    @unittest2.expectedFailure
++    @skipIfLinux
      def test_signal_watch_break_dwarf(self):
          """Test one signal thread with 5 watchpoint and breakpoint threads."""
          self.buildDwarf(dictionary=self.getBuildFlags())
@@ -207,23 +231,39 @@ index f0f2c3f..231b20c 100644
      @dwarf_test
      @skipIfFreeBSD # timing out on buildbot
      @skipIfRemoteDueToDeadlock
-+    @unittest2.expectedFailure
++    @skipIfLinux
      def test_signal_watch_break_dwarf(self):
          """Test with 5 watchpoint and breakpoint threads."""
+         self.buildDwarf(dictionary=self.getBuildFlags())
+@@ -285,6 +313,7 @@ class ConcurrentEventsTestCase(TestBase):
+     #
+     @dwarf_test
+     @skipIfFreeBSD # timing out on buildbot
++    @skipIfLinux
+     def test_crash_with_break_dwarf(self):
+         """ Test a thread that crashes while another thread hits a breakpoint."""
          self.buildDwarf(dictionary=self.getBuildFlags())
 @@ -293,6 +322,7 @@ class ConcurrentEventsTestCase(TestBase):
      @dwarf_test
      @skipIfFreeBSD # timing out on buildbot
      @skipIfRemoteDueToDeadlock
-+    @unittest2.expectedFailure
++    @skipIfLinux
      def test_crash_with_watchpoint_dwarf(self):
          """ Test a thread that crashes while another thread hits a watchpoint."""
+         self.buildDwarf(dictionary=self.getBuildFlags())
+@@ -300,6 +330,7 @@ class ConcurrentEventsTestCase(TestBase):
+ 
+     @dwarf_test
+     @skipIfFreeBSD # timing out on buildbot
++    @skipIfLinux
+     def test_crash_with_signal_dwarf(self):
+         """ Test a thread that crashes while another thread generates a signal."""
          self.buildDwarf(dictionary=self.getBuildFlags())
 @@ -308,6 +339,7 @@ class ConcurrentEventsTestCase(TestBase):
      @dwarf_test
      @skipIfFreeBSD # timing out on buildbot
      @skipIfRemoteDueToDeadlock
-+    @unittest2.expectedFailure
++    @skipIfLinux
      def test_crash_with_watchpoint_breakpoint_signal_dwarf(self):
          """ Test a thread that crashes while other threads generate a signal and hit a watchpoint and breakpoint. """
          self.buildDwarf(dictionary=self.getBuildFlags())
@@ -231,7 +271,15 @@ index f0f2c3f..231b20c 100644
      @dwarf_test
      @skipIfFreeBSD # timing out on buildbot
      @skipIfRemoteDueToDeadlock
-+    @unittest2.expectedFailure
++    @skipIfLinux
      def test_delayed_crash_with_breakpoint_watchpoint_dwarf(self):
          """ Test a thread with a delayed crash while other threads hit a watchpoint and a breakpoint. """
+         self.buildDwarf(dictionary=self.getBuildFlags())
+@@ -328,6 +361,7 @@ class ConcurrentEventsTestCase(TestBase):
+ 
+     @dwarf_test
+     @skipIfFreeBSD # timing out on buildbot
++    @skipIfLinux
+     def test_delayed_crash_with_breakpoint_signal_dwarf(self):
+         """ Test a thread with a delayed crash while other threads generate a signal and hit a breakpoint. """
          self.buildDwarf(dictionary=self.getBuildFlags())


### PR DESCRIPTION
These are still flaky.

This reverts commit 05b29a476aed923353a1d60fb487442e2080fbe0.