### PR TITLE
Use tid instead of pid for ptrace calls.

### DIFF
--- a/Sources/Target/FreeBSD/X86/ProcessX86.cpp
+++ b/Sources/Target/FreeBSD/X86/ProcessX86.cpp
@@ -9,6 +9,7 @@
 //
 
 #include "DebugServer2/Target/Process.h"
+#include "DebugServer2/Target/Thread.h"
 #include "DebugServer2/Architecture/X86/SoftwareBreakpointManager.h"
 
 //
@@ -82,7 +83,8 @@ ErrorCode Process::allocateMemory(size_t size, uint32_t protection,
   //
   // Code inject and execute
   //
-  error = ptrace().execute(_pid, info, &codestr[0], codestr.size(), *address);
+  error = ptrace().execute(_currentThread->tid(), info, &codestr[0],
+                           codestr.size(), *address);
   if (error != kSuccess)
     return error;
 
@@ -108,7 +110,8 @@ ErrorCode Process::deallocateMemory(uint64_t address, size_t size) {
   // Code inject and execute
   //
   uint64_t result = 0;
-  error = ptrace().execute(_pid, info, &codestr[0], codestr.size(), result);
+  error = ptrace().execute(_currentThread->tid(), info, &codestr[0],
+                           codestr.size(), result);
   if (error != kSuccess)
     return error;
 

--- a/Sources/Target/FreeBSD/X86_64/ProcessX86_64.cpp
+++ b/Sources/Target/FreeBSD/X86_64/ProcessX86_64.cpp
@@ -9,6 +9,7 @@
 //
 
 #include "DebugServer2/Target/Process.h"
+#include "DebugServer2/Target/Thread.h"
 #include "DebugServer2/Architecture/X86/SoftwareBreakpointManager.h"
 
 // Include system header files for constants.
@@ -81,7 +82,8 @@ ErrorCode Process::allocateMemory(size_t size, uint32_t protection,
   //
   // Code inject and execute
   //
-  error = ptrace().execute(_pid, info, &codestr[0], codestr.size(), *address);
+  error = ptrace().execute(_currentThread->tid(), info, &codestr[0],
+                           codestr.size(), *address);
   if (error != kSuccess)
     return error;
 
@@ -107,7 +109,8 @@ ErrorCode Process::deallocateMemory(uint64_t address, size_t size) {
   // Code inject and execute
   //
   uint64_t result = 0;
-  error = ptrace().execute(_pid, info, &codestr[0], codestr.size(), result);
+  error = ptrace().execute(_currentThread->tid(), info, &codestr[0],
+                           codestr.size(), result);
   if (error != kSuccess)
     return error;
 

--- a/Sources/Target/Linux/ARM/ProcessARM.cpp
+++ b/Sources/Target/Linux/ARM/ProcessARM.cpp
@@ -9,6 +9,7 @@
 //
 
 #include "DebugServer2/Architecture/ARM/SoftwareBreakpointManager.h"
+#include "DebugServer2/Target/Thread.h"
 #include "DebugServer2/Host/Platform.h"
 #include "DebugServer2/Support/Stringify.h"
 #include "DebugServer2/Target/Process.h"
@@ -294,7 +295,8 @@ ErrorCode Process::allocateMemory(size_t size, uint32_t protection,
   //
   // Code inject and execute
   //
-  error = ptrace().execute(_pid, info, &codestr[0], codestr.size(), *address);
+  error = ptrace().execute(_currentThread->tid(), info, &codestr[0],
+                           codestr.size(), *address);
   if (error != kSuccess)
     return error;
 
@@ -334,7 +336,8 @@ ErrorCode Process::deallocateMemory(uint64_t address, size_t size) {
   // Code inject and execute
   //
   uint64_t result = 0;
-  error = ptrace().execute(_pid, info, &codestr[0], codestr.size(), result);
+  error = ptrace().execute(_currentThread->tid(), info, &codestr[0],
+                           codestr.size(), result);
   if (error != kSuccess)
     return error;
 

--- a/Sources/Target/Linux/X86/ProcessX86.cpp
+++ b/Sources/Target/Linux/X86/ProcessX86.cpp
@@ -9,6 +9,7 @@
 //
 
 #include "DebugServer2/Target/Process.h"
+#include "DebugServer2/Target/Thread.h"
 #include "DebugServer2/Architecture/X86/SoftwareBreakpointManager.h"
 
 //
@@ -82,7 +83,8 @@ ErrorCode Process::allocateMemory(size_t size, uint32_t protection,
   //
   // Code inject and execute
   //
-  error = ptrace().execute(_pid, info, &codestr[0], codestr.size(), *address);
+  error = ptrace().execute(_currentThread->tid(), info, &codestr[0],
+                           codestr.size(), *address);
   if (error != kSuccess)
     return error;
 
@@ -108,7 +110,8 @@ ErrorCode Process::deallocateMemory(uint64_t address, size_t size) {
   // Code inject and execute
   //
   uint64_t result = 0;
-  error = ptrace().execute(_pid, info, &codestr[0], codestr.size(), result);
+  error = ptrace().execute(_currentThread->tid(), info, &codestr[0],
+                           codestr.size(), result);
   if (error != kSuccess)
     return error;
 

--- a/Sources/Target/Linux/X86_64/ProcessX86_64.cpp
+++ b/Sources/Target/Linux/X86_64/ProcessX86_64.cpp
@@ -10,6 +10,7 @@
 
 #include "DebugServer2/Architecture/X86/SoftwareBreakpointManager.h"
 #include "DebugServer2/Target/Process.h"
+#include "DebugServer2/Target/Thread.h"
 
 #include <cstdlib>
 #include <sys/mman.h>
@@ -80,7 +81,8 @@ ErrorCode Process::allocateMemory(size_t size, uint32_t protection,
   //
   // Code inject and execute
   //
-  error = ptrace().execute(_pid, info, &codestr[0], codestr.size(), *address);
+  error = ptrace().execute(_currentThread->tid(), info, &codestr[0],
+                           codestr.size(), *address);
   if (error != kSuccess)
     return error;
 
@@ -106,7 +108,8 @@ ErrorCode Process::deallocateMemory(uint64_t address, size_t size) {
   // Code inject and execute
   //
   uint64_t result = 0;
-  error = ptrace().execute(_pid, info, &codestr[0], codestr.size(), result);
+  error = ptrace().execute(_currentThread->tid(), info, &codestr[0],
+                           codestr.size(), result);
   if (error != kSuccess)
     return error;
 


### PR DESCRIPTION
ptrace calls will fail if the main thread is sleeping at the time of the call