### PR TITLE
Fix support for ARM VFP registers

### DIFF
--- a/Headers/DebugServer2/GDBRemote/Types.h
+++ b/Headers/DebugServer2/GDBRemote/Types.h
@@ -146,6 +146,7 @@ struct RegisterInfo {
   ssize_t byteOffset;
   ssize_t gccRegisterIndex;
   ssize_t dwarfRegisterIndex;
+  uint32_t regno;
   Encoding encoding;
   Format format;
   std::vector<uint32_t> containerRegisters;

--- a/Sources/GDBRemote/DebugSessionImpl.cpp
+++ b/Sources/GDBRemote/DebugSessionImpl.cpp
@@ -343,6 +343,7 @@ ErrorCode DebugSessionImpl::onQueryRegisterInfo(Session &, uint32_t regno,
   info.byteOffset = reginfo.Def->LLDBOffset;
   info.gccRegisterIndex = reginfo.Def->GCCRegisterNumber;
   info.dwarfRegisterIndex = reginfo.Def->DWARFRegisterNumber;
+  info.regno = regno;
 
   if (reginfo.Def->Format == Architecture::kFormatVector) {
     info.encoding = RegisterInfo::kEncodingVector;

--- a/Sources/GDBRemote/Structures.cpp
+++ b/Sources/GDBRemote/Structures.cpp
@@ -643,6 +643,10 @@ std::string RegisterInfo::encode(int xmlSet) const {
       regInfo.push_back(std::make_pair("set", setName));
   }
 
+  if (xml) {
+    regInfo.push_back(std::make_pair("regnum", ds2::ToString(regno)));
+  }
+
   if (!(gccRegisterIndex < 0))
     regInfo.push_back(std::make_pair(xml ? "gcc_regnum" : "gcc",
                                      ds2::ToString(gccRegisterIndex)));
@@ -659,7 +663,8 @@ std::string RegisterInfo::encode(int xmlSet) const {
     for (size_t n = 0; n < containerRegisters.size(); n++) {
       if (n != 0)
         contStream << ',';
-      contStream << std::hex << containerRegisters[n] << std::dec;
+      contStream << (xml ? std::dec : std::hex) << containerRegisters[n]
+                 << std::dec;
     }
     regInfo.push_back(std::make_pair(xml ? "value_regnums" : "container-regs",
                                      contStream.str()));
@@ -670,7 +675,8 @@ std::string RegisterInfo::encode(int xmlSet) const {
     for (size_t n = 0; n < invalidateRegisters.size(); n++) {
       if (n != 0)
         invStream << ',';
-      invStream << std::hex << invalidateRegisters[n] << std::dec;
+      invStream << (xml ? std::dec : std::hex) << invalidateRegisters[n]
+                << std::dec;
     }
     regInfo.push_back(std::make_pair(
         xml ? "invalidate_regnums" : "invalidate-regs", invStream.str()));

--- a/Sources/Host/Linux/ARM/PTraceARM.cpp
+++ b/Sources/Host/Linux/ARM/PTraceARM.cpp
@@ -102,13 +102,11 @@ ErrorCode PTrace::readCPUState(ProcessThreadId const &ptid, ProcessInfo const &,
   //
   std::memcpy(state.gp.regs, gprs.uregs, sizeof(state.gp.regs));
 
-#if (__ARM_ARCH >= 7)
   static_assert(sizeof(state.vfp) == ARM_VFPREGS_SIZE,
                 "sizeof(ARM::CPUState.vfp) does not match ARM_VFPREGS_SIZE");
 
   if (wrapPtrace(PTRACE_GETVFPREGS, pid, nullptr, &state.vfp) < 0)
     return Platform::TranslateError();
-#endif
 
   //
   // Read hardware breakpoints and watchpoints.
@@ -176,13 +174,11 @@ ErrorCode PTrace::writeCPUState(ProcessThreadId const &ptid,
   if (wrapPtrace(PTRACE_SETREGS, pid, nullptr, &gprs) < 0)
     return Platform::TranslateError();
 
-#if (__ARM_ARCH >= 7)
   static_assert(sizeof(state.vfp) == ARM_VFPREGS_SIZE,
                 "sizeof(ARM::CPUState.vfp) does not match ARM_VFPREGS_SIZE");
 
   if (wrapPtrace(PTRACE_SETVFPREGS, pid, nullptr, &state.vfp) < 0)
     return Platform::TranslateError();
-#endif
 
   //
   // Write hardware breakpoints and watchpoints.


### PR DESCRIPTION
When parsing the registers in XML LLDB expects:
- the register number for each register
- value_regnums and invalidate-regs to be in decimal, not hex