### PR TITLE
Implementation of QEnableCompression

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,6 +259,10 @@ if (${ENABLE_LOGCAT})
   target_compile_definitions(ds2 PRIVATE ENABLE_LOGCAT)
 endif ()
 
+if ("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
+  target_link_libraries(ds2 z)
+endif ()
+
 if ("${CMAKE_SYSTEM_NAME}" MATCHES "FreeBSD")
   target_link_libraries(ds2 util procstat)
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,7 @@ set(SUPPORT_COMMON_SOURCES
     Sources/MessageQueue.cpp
     Sources/SessionThread.cpp
     Sources/Support/Stringify.cpp
+    Sources/Support/CompressionBase.cpp
     Sources/Utils/Log.cpp
     Sources/Utils/OptParse.cpp
     Sources/main.cpp
@@ -190,6 +191,7 @@ set(SUPPORT_POSIX_SOURCES
 
 set(SUPPORT_Linux_SOURCES
     ${SUPPORT_POSIX_SOURCES}
+    Sources/Support/Linux/Compression.cpp
     )
 
 set(SUPPORT_FreeBSD_SOURCES

--- a/Headers/DebugServer2/GDBRemote/Session.h
+++ b/Headers/DebugServer2/GDBRemote/Session.h
@@ -108,6 +108,8 @@ private:
                                  std::string const &args);
   void Handle_QStartNoAckMode(ProtocolInterpreter::Handler const &,
                               std::string const &);
+  void Handle_QEnableCompression(ProtocolInterpreter::Handler const &,
+                                 std::string const &);
   void Handle_QSyncThreadState(ProtocolInterpreter::Handler const &,
                                std::string const &);
   void Handle_QThreadSuffixSupported(ProtocolInterpreter::Handler const &,

--- a/Headers/DebugServer2/GDBRemote/SessionBase.h
+++ b/Headers/DebugServer2/GDBRemote/SessionBase.h
@@ -14,6 +14,7 @@
 #include "DebugServer2/GDBRemote/Types.h"
 #include "DebugServer2/GDBRemote/PacketProcessor.h"
 #include "DebugServer2/GDBRemote/ProtocolInterpreter.h"
+#include "DebugServer2/Support/Compression.h"
 #include "DebugServer2/Host/Channel.h"
 
 namespace ds2 {
@@ -28,6 +29,7 @@ private:
   ProtocolInterpreter _interpreter;
 
 protected:
+  Support::Compression _compression;
   SessionDelegate *_delegate;
   bool _ackmode;
 
@@ -65,6 +67,12 @@ public:
 
 protected:
   inline void setAckMode(bool enabled) { _ackmode = enabled; }
+
+protected:
+  inline void enableCompression() { _compression.enable(true); }
+  inline ErrorCode setCompressionType(std::string type, int min) {
+    return _compression.setAlgo(type, min);
+  }
 
 public:
   inline ProtocolInterpreter &interpreter() const {

--- a/Headers/DebugServer2/Support/Compression.h
+++ b/Headers/DebugServer2/Support/Compression.h
@@ -1,0 +1,37 @@
+//
+// Copyright (c) 2015, Corentin Derbois <cderbois@gmail.com>.
+// All rights reserved.
+//
+// This source code is licensed under the University of Illinois/NCSA Open
+// Source License found in the LICENSE file in the root directory of this
+// source tree. An additional grant of patent rights can be found in the
+// PATENTS file in the same directory.
+//
+
+#ifndef __DebugServer2_Support_Compression_h
+#define __DebugServer2_Support_Compression_h
+
+#include "DebugServer2/Base.h"
+#include "DebugServer2/Constants.h"
+#include "DebugServer2/Support/CompressionBase.h"
+
+#if defined(OS_LINUX)
+#include "DebugServer2/Support/Linux/Compression.h"
+#endif
+
+namespace ds2 {
+namespace Support {
+
+#if defined(OS_LINUX)
+using Linux::Compression;
+#else
+class Compression : public CompressionBase {
+
+public:
+  static std::string getSupported(void) { return nullptr; }
+};
+#endif
+}
+}
+
+#endif // !__DebugServer2_Support_Compression_h

--- a/Headers/DebugServer2/Support/CompressionBase.h
+++ b/Headers/DebugServer2/Support/CompressionBase.h
@@ -1,0 +1,52 @@
+//
+// Copyright (c) 2015, Corentin Derbois <cderbois@gmail.com>.
+// All rights reserved.
+//
+// This source code is licensed under the University of Illinois/NCSA Open
+// Source License found in the LICENSE file in the root directory of this
+// source tree. An additional grant of patent rights can be found in the
+// PATENTS file in the same directory.
+//
+
+#ifndef __DebugServer2_Support_CompressionBase_h
+#define __DebugServer2_Support_CompressionBase_h
+
+#include "DebugServer2/Base.h"
+#include "DebugServer2/Constants.h"
+
+#include <string>
+
+namespace ds2 {
+namespace Support {
+
+class CompressionBase {
+
+public:
+  enum Algo { kNone, kLz4, kLzfse, kLzma, kZlibDeflate };
+
+public:
+  CompressionBase();
+  virtual ~CompressionBase();
+
+public:
+  virtual bool isEnable(void) const { return _enable; }
+  virtual void enable(bool enable) { _enable = enable; }
+
+public:
+  virtual ErrorCode setAlgo(std::string algo, int min);
+
+public:
+  virtual std::string compress(const std::string &source);
+
+protected:
+  static const int defaultMin = 384; /* lldb default min */
+
+protected:
+  bool _enable;
+  Algo _algo;
+  int _min;
+};
+}
+}
+
+#endif // !__DebugServer2_Support_CompressionBase_h

--- a/Headers/DebugServer2/Support/Linux/Compression.h
+++ b/Headers/DebugServer2/Support/Linux/Compression.h
@@ -19,7 +19,20 @@ namespace ds2 {
 namespace Support {
 namespace Linux {
 
-class Compression : public Support::CompressionBase {};
+#define super Support::CompressionBase
+#define zLibMetaDataSize 10
+
+class Compression : public Support::CompressionBase {
+
+public:
+  static std::string getSupported(void);
+
+public:
+  virtual ErrorCode setAlgo(std::string algo, int min);
+
+public:
+  virtual std::string compress(const std::string &source);
+};
 }
 }
 }

--- a/Headers/DebugServer2/Support/Linux/Compression.h
+++ b/Headers/DebugServer2/Support/Linux/Compression.h
@@ -1,0 +1,27 @@
+//
+// Copyright (c) 2015, Corentin Derbois <cderbois@gmail.com>.
+// All rights reserved.
+//
+// This source code is licensed under the University of Illinois/NCSA Open
+// Source License found in the LICENSE file in the root directory of this
+// source tree. An additional grant of patent rights can be found in the
+// PATENTS file in the same directory.
+//
+
+#ifndef __DebugServer2_Support_Linux_Compression_h
+#define __DebugServer2_Support_Linux_Compression_h
+
+#include "DebugServer2/Base.h"
+#include "DebugServer2/Constants.h"
+#include "DebugServer2/Support/CompressionBase.h"
+
+namespace ds2 {
+namespace Support {
+namespace Linux {
+
+class Compression : public Support::CompressionBase {};
+}
+}
+}
+
+#endif // !__DebugServer2_Support_Linux_Compression_h

--- a/Sources/GDBRemote/DebugSessionImpl.cpp
+++ b/Sources/GDBRemote/DebugSessionImpl.cpp
@@ -15,6 +15,7 @@
 #include "DebugServer2/GDBRemote/Session.h"
 #include "DebugServer2/Host/Platform.h"
 #include "DebugServer2/Support/Stringify.h"
+#include "DebugServer2/Support/Compression.h"
 #include "DebugServer2/Utils/HexValues.h"
 #include "DebugServer2/Utils/Log.h"
 
@@ -111,6 +112,10 @@ DebugSessionImpl::onQuerySupported(Session &session,
   localFeatures.push_back(std::string("ConditionalTracepoints-"));
   localFeatures.push_back(std::string("TracepointSource-"));
   localFeatures.push_back(std::string("EnableDisableTracepoints-"));
+
+  std::string compressionFeature = Support::Compression::getSupported();
+  if (!compressionFeature.empty())
+    localFeatures.push_back(compressionFeature);
 
   return kSuccess;
 }

--- a/Sources/GDBRemote/Session.cpp
+++ b/Sources/GDBRemote/Session.cpp
@@ -95,6 +95,7 @@ Session::Session(CompatibilityMode mode) : _compatMode(mode) {
   REGISTER_HANDLER_EQUALS_1(QSetSTDOUT);
   REGISTER_HANDLER_EQUALS_1(QSetWorkingDir);
   REGISTER_HANDLER_EQUALS_1(QStartNoAckMode);
+  REGISTER_HANDLER_EQUALS_1(QEnableCompression);
   REGISTER_HANDLER_EQUALS_1(QSyncThreadState);
   REGISTER_HANDLER_EQUALS_1(QThreadSuffixSupported);
   REGISTER_HANDLER_EQUALS_1(Qbtrace);
@@ -1223,6 +1224,33 @@ void Session::Handle_QStartNoAckMode(ProtocolInterpreter::Handler const &,
                                      std::string const &) {
   setAckMode(false);
   sendOK();
+}
+
+//
+// Packet:        QEnableCompression:type:<type>;[minsize:<size>;]
+// Description:   Request that the remote stub enable the compression
+//                with a specified type.
+// Compatibility: LLDB
+//
+void Session::Handle_QEnableCompression(ProtocolInterpreter::Handler const &,
+                                     std::string const &args) {
+  uint32_t min = -1;
+  std::string type = "";
+  ErrorCode err;
+
+  ParseList(args, ';', [&](std::string const &arg) {
+    if (arg.compare(0, 5, "type:") == 0) {
+      type = &arg[5];
+    } else if (arg.compare(0, 8, "minsize:") == 0) {
+      min = std::strtoul(&arg[8], nullptr, 0);
+    }
+  });
+
+  err = setCompressionType(type, min);
+  sendError(err);
+
+  if (err == kSuccess)
+    enableCompression();
 }
 
 //

--- a/Sources/GDBRemote/SessionBase.cpp
+++ b/Sources/GDBRemote/SessionBase.cpp
@@ -81,6 +81,14 @@ bool SessionBase::send(std::string const &data, bool escaped) {
   std::ostringstream ss;
   std::string encoded;
   std::string const *datap = &data;
+  bool compressed = false;
+
+  if (_compression.isEnable()) {
+    encoded = _compression.compress(data);
+    datap = &encoded;
+    escaped = true;
+    compressed = encoded[0] == 'C';
+  }
 
   //
   // If data contains $, #, } or * we need to escape the
@@ -97,7 +105,8 @@ bool SessionBase::send(std::string const &data, bool escaped) {
      << (unsigned)csum;
 
   std::string final_data = ss.str();
-  DS2LOG(Packet, "putpkt(\"%s\", %u)", final_data.c_str(),
+  DS2LOG(Packet, "putpkt(\"%s\", %u)",
+         (compressed ? "<compressed>" : final_data.c_str()),
          (unsigned)final_data.length());
 
   return _channel->send(final_data);

--- a/Sources/Support/CompressionBase.cpp
+++ b/Sources/Support/CompressionBase.cpp
@@ -1,0 +1,52 @@
+//
+// Copyright (c) 2015, Corentin Derbois <cderbois@gmail.com>.
+// All rights reserved.
+//
+// This source code is licensed under the University of Illinois/NCSA Open
+// Source License found in the LICENSE file in the root directory of this
+// source tree. An additional grant of patent rights can be found in the
+// PATENTS file in the same directory.
+//
+
+#include "DebugServer2/Support/CompressionBase.h"
+#include "DebugServer2/Utils/Log.h"
+
+#include <string>
+
+namespace ds2 {
+namespace Support {
+
+CompressionBase::CompressionBase() : _enable(false), _algo(kNone), _min(0) {}
+
+CompressionBase::~CompressionBase() {}
+
+ErrorCode CompressionBase::setAlgo(std::string algo, int min) {
+  _algo = kNone;
+
+  if (algo == "lzfse")
+    _algo = kLzfse;
+  else if (algo == "zlib-deflate")
+    _algo = kZlibDeflate;
+  else if (algo == "lz4")
+    _algo = kLz4;
+  else if (algo == "lzma")
+    _algo = kLzma;
+
+  if (_algo == kNone)
+    return kErrorInvalidArgument;
+
+  if (min != -1)
+    _min = min;
+
+  return kSuccess;
+}
+
+std::string CompressionBase::compress(const std::string &source) {
+  std::string compressed;
+
+  DS2BUG("not implemented");
+
+  return compressed.assign(source);
+}
+}
+}

--- a/Sources/Support/Linux/Compression.cpp
+++ b/Sources/Support/Linux/Compression.cpp
@@ -11,8 +11,97 @@
 #include "DebugServer2/Support/Linux/Compression.h"
 #include "DebugServer2/Utils/Log.h"
 
+#include <unistd.h>
+#include <vector>
+#include <sstream>
+#include <cstring>
+#include <zlib.h>
+
 namespace ds2 {
 namespace Support {
-namespace Linux {}
+namespace Linux {
+
+std::string Compression::getSupported(void) {
+  std::ostringstream output;
+
+  output << "qXfer:features:read+;";
+  output << "SupportedCompressions=zlib-deflate;";
+  output << "DefaultCompressionMinSize=" << defaultMin;
+
+  return output.str();
+}
+
+ErrorCode Compression::setAlgo(std::string algo, int min) {
+  ErrorCode err;
+
+  err = super::setAlgo(algo, min);
+  if (err != kSuccess)
+    return err;
+
+  /*
+   * we just support one algo for the moment so
+   * if lldb return an other algo that we propose
+   * let's catch that here.
+   */
+
+  if (_algo != kZlibDeflate)
+    return kErrorUnsupported;
+
+  return kSuccess;
+}
+
+std::string Compression::compress(const std::string &source) {
+  /*
+   * The size of the metadate for Zlib is 10 bytes. Let's add
+   * this size to the source size. This will insure that the
+   * output buffer is big enough.
+   */
+  std::vector<uint8_t> compressed_buf(source.size() + zLibMetaDataSize);
+  std::ostringstream ss;
+  std::string compressed;
+  z_stream stream;
+  int state;
+
+  if (source.size() < (uint32_t)_min) {
+    // Uncompressed format $N<uncompressed payload>#00
+    return "N" + source;
+  }
+
+  ::memset(&stream, 0, sizeof(z_stream));
+
+  stream.next_in = (Bytef *)source.c_str();
+  stream.avail_in = (uInt)source.size();
+  stream.next_out = (Bytef *)compressed_buf.data();
+  stream.avail_out = (uInt)source.size() + zLibMetaDataSize;
+  stream.zalloc = Z_NULL;
+  stream.zfree = Z_NULL;
+  stream.opaque = Z_NULL;
+  deflateInit2(&stream, 5, Z_DEFLATED, -15, 8, Z_DEFAULT_STRATEGY);
+
+  state = deflate(&stream, Z_FINISH);
+  if (state != Z_STREAM_END && stream.avail_out == 0) {
+    // Uncompressed format $N<uncompressed payload>#00
+    return "N" + source;
+  }
+
+  // format: $C<size of uncompressed payload in base10>:<compressed payload>#00
+  ss << "C" << source.size() << ":";
+  compressed = ss.str();
+
+  for (size_t idx = 0; idx < stream.total_out; idx++) {
+    uint8_t byte = compressed_buf[idx];
+
+    if (byte == '\0' || byte == '}' || byte == '#' || byte == '$' ||
+        byte == '*') {
+      compressed.push_back(0x7D);
+      compressed.push_back(byte ^ 0x20);
+    } else {
+      compressed.push_back(byte);
+    }
+  }
+
+  return compressed;
+}
+}
 }
 }

--- a/Sources/Support/Linux/Compression.cpp
+++ b/Sources/Support/Linux/Compression.cpp
@@ -1,0 +1,18 @@
+//
+// Copyright (c) 2015, Corentin Derbois <cderbois@gmail.com>.
+// All rights reserved.
+//
+// This source code is licensed under the University of Illinois/NCSA Open
+// Source License found in the LICENSE file in the root directory of this
+// source tree. An additional grant of patent rights can be found in the
+// PATENTS file in the same directory.
+//
+
+#include "DebugServer2/Support/Linux/Compression.h"
+#include "DebugServer2/Utils/Log.h"
+
+namespace ds2 {
+namespace Support {
+namespace Linux {}
+}
+}


### PR DESCRIPTION
 This feature is supported by lldb from 3.7.0.

I think it will be test on Travis (will check) since it's enable by default on linux. But I didn't found specific test for it.