### PR TITLE
Remove some duplicate code in PTrace.

### DIFF
--- a/Headers/DebugServer2/Host/Darwin/PTrace.h
+++ b/Headers/DebugServer2/Host/Darwin/PTrace.h
@@ -13,9 +13,6 @@
 
 #include "DebugServer2/Host/POSIX/PTrace.h"
 
-#include <sys/ptrace.h>
-#include <sys/types.h>
-
 namespace ds2 {
 namespace Host {
 namespace Darwin {
@@ -30,10 +27,6 @@ public:
 public:
   virtual ErrorCode traceMe(bool disableASLR);
   virtual ErrorCode traceThat(ProcessId pid);
-
-public:
-  virtual ErrorCode attach(ProcessId pid);
-  virtual ErrorCode detach(ProcessId pid);
 
 public:
   virtual ErrorCode kill(ProcessThreadId const &ptid, int signal);
@@ -73,15 +66,6 @@ public:
 protected:
   void initCPUState(ProcessId pid);
   void doneCPUState();
-
-protected:
-  template <typename CommandType, typename AddrType, typename DataType>
-  long wrapPtrace(CommandType request, pid_t pid, AddrType addr,
-                  DataType data) {
-    typedef int ptrace_request_t;
-    return ::ptrace(static_cast<ptrace_request_t>(request), pid,
-                    (char *)(uintptr_t)addr, (int)(uintptr_t)data);
-  }
 
 public:
   PTracePrivateData *_privateData;

--- a/Headers/DebugServer2/Host/FreeBSD/PTrace.h
+++ b/Headers/DebugServer2/Host/FreeBSD/PTrace.h
@@ -11,8 +11,6 @@
 #ifndef __DebugServer2_Host_FreeBSD_PTrace_h
 #define __DebugServer2_Host_FreeBSD_PTrace_h
 
-#include <sys/ptrace.h>
-
 #include "DebugServer2/Host/POSIX/PTrace.h"
 
 namespace ds2 {
@@ -29,10 +27,6 @@ public:
 public:
   virtual ErrorCode traceMe(bool disableASLR);
   virtual ErrorCode traceThat(ProcessId pid);
-
-public:
-  virtual ErrorCode attach(ProcessId pid);
-  virtual ErrorCode detach(ProcessId pid);
 
 public:
   virtual ErrorCode kill(ProcessThreadId const &ptid, int signal);
@@ -76,15 +70,6 @@ public:
 protected:
   void initCPUState(ProcessId pid);
   void doneCPUState();
-
-protected:
-  template <typename CommandType, typename AddrType, typename DataType>
-  long wrapPtrace(CommandType request, pid_t pid, AddrType addr,
-                  DataType data) {
-    typedef int ptrace_request_t;
-    return ::ptrace(static_cast<ptrace_request_t>(request), pid,
-                    (char *)(uintptr_t)addr, (int)(uintptr_t)data);
-  }
 
 public:
   PTracePrivateData *_privateData;

--- a/Headers/DebugServer2/Host/Linux/PTrace.h
+++ b/Headers/DebugServer2/Host/Linux/PTrace.h
@@ -12,12 +12,7 @@
 #define __DebugServer2_Host_Linux_PTrace_h
 
 #include "DebugServer2/Host/POSIX/PTrace.h"
-#include "DebugServer2/Support/Stringify.h"
 #include "DebugServer2/Utils/Log.h"
-
-#include <sys/ptrace.h>
-
-using ds2::Support::Stringify;
 
 namespace ds2 {
 namespace Host {
@@ -36,10 +31,6 @@ public:
 public:
   ErrorCode traceMe(bool disableASLR) override;
   ErrorCode traceThat(ProcessId pid) override;
-
-public:
-  ErrorCode attach(ProcessId pid) override;
-  ErrorCode detach(ProcessId pid) override;
 
 public:
   ErrorCode kill(ProcessThreadId const &ptid, int signal) override;
@@ -91,21 +82,6 @@ protected:
 protected:
   void initCPUState(ProcessId pid);
   void doneCPUState();
-
-protected:
-  template <typename CommandType, typename AddrType, typename DataType>
-  long wrapPtrace(CommandType request, pid_t pid, AddrType addr,
-                  DataType data) {
-#if defined(__ANDROID__)
-    typedef int ptrace_request_t;
-#else
-    typedef enum __ptrace_request ptrace_request_t;
-#endif
-    DS2LOG(Debug, "running ptrace command %s on pid %d",
-           Stringify::Ptrace(request), pid);
-    return ::ptrace(static_cast<ptrace_request_t>(request), pid,
-                    (void *)(uintptr_t)addr, (void *)(uintptr_t)data);
-  }
 
 public:
   PTracePrivateData *_privateData;

--- a/Sources/Host/Darwin/PTrace.cpp
+++ b/Sources/Host/Darwin/PTrace.cpp
@@ -15,8 +15,6 @@
 #include "DebugServer2/Host/Platform.h"
 #include "DebugServer2/Utils/Log.h"
 
-#include <sys/ptrace.h>
-
 #include <cerrno>
 #include <csignal>
 #include <cstdio>
@@ -44,33 +42,6 @@ ErrorCode PTrace::traceThat(ProcessId pid) {
     return kErrorInvalidArgument;
 
   return kSuccess; // kErrorUnsupported;
-}
-
-ErrorCode PTrace::attach(ProcessId pid) {
-  if (pid <= kAnyProcessId)
-    return kErrorProcessNotFound;
-
-  DS2LOG(Debug, "attaching to pid %" PRIu64, (uint64_t)pid);
-
-  if (wrapPtrace(PT_ATTACH, pid, nullptr, nullptr) < 0) {
-    ErrorCode error = Platform::TranslateError();
-    DS2LOG(Error, "Unable to attach: %d", error);
-    return error;
-  }
-
-  return kSuccess;
-}
-
-ErrorCode PTrace::detach(ProcessId pid) {
-  if (pid <= kAnyProcessId)
-    return kErrorProcessNotFound;
-
-  DS2LOG(Debug, "detaching from pid %" PRIu64, (uint64_t)pid);
-
-  if (wrapPtrace(PT_DETACH, pid, nullptr, nullptr) < 0)
-    return Platform::TranslateError();
-
-  return kSuccess;
 }
 
 ErrorCode PTrace::kill(ProcessThreadId const &ptid, int signal) {

--- a/Sources/Host/FreeBSD/PTrace.cpp
+++ b/Sources/Host/FreeBSD/PTrace.cpp
@@ -19,7 +19,6 @@
 #include <csignal>
 #include <cstdio>
 #include <limits>
-#include <sys/ptrace.h>
 #include <sys/thr.h>
 
 #define super ds2::Host::POSIX::PTrace
@@ -42,30 +41,6 @@ ErrorCode PTrace::traceMe(bool disableASLR) {
 ErrorCode PTrace::traceThat(ProcessId pid) {
   if (pid <= 0)
     return kErrorInvalidArgument;
-
-  return kSuccess;
-}
-
-ErrorCode PTrace::attach(ProcessId pid) {
-  if (pid <= kAnyProcessId)
-    return kErrorProcessNotFound;
-
-  DS2LOG(Debug, "attaching to pid %" PRIu64, (uint64_t)pid);
-
-  if (wrapPtrace(PT_ATTACH, pid, nullptr, nullptr) < 0)
-    return Platform::TranslateError();
-
-  return kSuccess;
-}
-
-ErrorCode PTrace::detach(ProcessId pid) {
-  if (pid <= kAnyProcessId)
-    return kErrorProcessNotFound;
-
-  DS2LOG(Debug, "detaching from pid %" PRIu64, (uint64_t)pid);
-
-  if (wrapPtrace(PT_DETACH, pid, nullptr, nullptr) < 0)
-    return Platform::TranslateError();
 
   return kSuccess;
 }

--- a/Sources/Host/Linux/PTrace.cpp
+++ b/Sources/Host/Linux/PTrace.cpp
@@ -19,7 +19,6 @@
 #include <csignal>
 #include <cstdio>
 #include <limits>
-#include <sys/ptrace.h>
 #include <sys/wait.h>
 
 #define super ds2::Host::POSIX::PTrace
@@ -86,30 +85,6 @@ ErrorCode PTrace::traceThat(ProcessId pid) {
            pid, strerror(errno));
     return Platform::TranslateError();
   }
-
-  return kSuccess;
-}
-
-ErrorCode PTrace::attach(ProcessId pid) {
-  if (pid <= kAnyProcessId)
-    return kErrorProcessNotFound;
-
-  DS2LOG(Debug, "attaching to pid %" PRIu64, (uint64_t)pid);
-
-  if (wrapPtrace(PTRACE_ATTACH, pid, nullptr, nullptr) < 0)
-    return Platform::TranslateError();
-
-  return kSuccess;
-}
-
-ErrorCode PTrace::detach(ProcessId pid) {
-  if (pid <= kAnyProcessId)
-    return kErrorProcessNotFound;
-
-  DS2LOG(Debug, "detaching from pid %" PRIu64, (uint64_t)pid);
-
-  if (wrapPtrace(PTRACE_DETACH, pid, nullptr, nullptr) < 0)
-    return Platform::TranslateError();
 
   return kSuccess;
 }

--- a/Sources/Support/POSIX/Stringify.cpp
+++ b/Sources/Support/POSIX/Stringify.cpp
@@ -14,8 +14,10 @@
 
 #include <errno.h>
 #include <signal.h>
-#include <sys/ptrace.h>
+// clang-format off
 #include <sys/types.h>
+#include <sys/ptrace.h>
+// clang-format on
 
 namespace ds2 {
 namespace Support {


### PR DESCRIPTION
A lot of code is identical between the Linux, FreeBSD and Darwin
implementations of our ptrace abstraction. This commit moves a couple of
functions up into the POSIX implementation.

There are probably more methods that could be moved in the same way.