### PR TITLE
Allow several options to be set by env vars

### DIFF
--- a/Headers/DebugServer2/Utils/Log.h
+++ b/Headers/DebugServer2/Utils/Log.h
@@ -42,6 +42,8 @@ void SetLogOutputStream(FILE *stream);
 void Log(int level, char const *classname, char const *funcname,
          char const *format, ...) DS2_ATTRIBUTE_PRINTF(4, 5);
 
+void Print(char const *format, ...);
+
 #if defined(__DS2_LOG_CLASS_NAME__)
 #define DS2LOG(LVL, ...)                                                       \
   ds2::Log(ds2::kLogLevel##LVL, __DS2_LOG_CLASS_NAME__, __FUNCTION__,          \

--- a/Headers/DebugServer2/Utils/OptParse.h
+++ b/Headers/DebugServer2/Utils/OptParse.h
@@ -11,6 +11,8 @@
 #ifndef __DebugServer2_Utils_OptParse_h
 #define __DebugServer2_Utils_OptParse_h
 
+#include "DebugServer2/Types.h"
+
 #include <map>
 #include <string>
 #include <vector>
@@ -27,10 +29,11 @@ public:
 
 public:
   void addOption(OptionType type, std::string const &name, char shortName,
-                 std::string const &help = std::string(), bool hidden = false);
+                 std::string const &help = std::string(), bool hidden = false,
+                 std::string const &envVarName = std::string());
 
 public:
-  int parse(int argc, char **argv, std::string &host, std::string &port);
+  int parse(int argc, char **argv, EnvironmentBlock const &env);
 
 public:
   bool getBool(std::string const &name);
@@ -39,6 +42,9 @@ public:
 
 public:
   void usageDie(std::string const &message = std::string());
+
+private:
+  void UpdateOptionsFromEnvVars(EnvironmentBlock const &env);
 
 private:
   struct OptionStorage {
@@ -51,6 +57,23 @@ private:
     } values;
     std::string help;
     bool hidden;
+    std::string envVarName;
+    bool isSet;
+
+    void setBool(bool value) {
+      isSet = true;
+      values.boolValue = value;
+    }
+
+    void setString(std::string value) {
+      isSet = true;
+      values.stringValue = value;
+    }
+
+    void addToVector(std::string const &value) {
+      isSet = true;
+      values.vectorValue.push_back(value);
+    }
   };
 
   typedef std::map<std::string, OptionStorage> OptionCollection;

--- a/Sources/Utils/Log.cpp
+++ b/Sources/Utils/Log.cpp
@@ -166,4 +166,23 @@ void Log(int level, char const *classname, char const *funcname,
   vLog(level, classname, funcname, format, ap);
   va_end(ap);
 }
+
+void Print(char const *format, ...) {
+  va_list ap, sap;
+
+  va_start(ap, format);
+  va_copy(sap, ap);
+
+  std::vector<char> line(ds2::Utils::VSNPrintf(nullptr, 0, format, ap) + 1);
+  ds2::Utils::VSNPrintf(line.data(), line.size(), format, sap);
+
+  va_end(ap);
+  va_end(sap);
+
+  fputs(line.data(), stderr);
+#if defined(OS_WIN32)
+  OutputDebugStringA(line.data());
+#endif
+};
+
 }

--- a/Sources/Utils/Log.cpp
+++ b/Sources/Utils/Log.cpp
@@ -184,5 +184,4 @@ void Print(char const *format, ...) {
   OutputDebugStringA(line.data());
 #endif
 };
-
 }

--- a/Sources/Utils/OptParse.cpp
+++ b/Sources/Utils/OptParse.cpp
@@ -151,30 +151,12 @@ std::vector<std::string> const &OptParse::getVector(std::string const &name) {
   return get(name, vectorOption).values.vectorValue;
 }
 
-static void print(char const *format, ...) {
-  va_list ap, sap;
-
-  va_start(ap, format);
-  va_copy(sap, ap);
-
-  std::vector<char> line(ds2::Utils::VSNPrintf(nullptr, 0, format, ap) + 1);
-  ds2::Utils::VSNPrintf(line.data(), line.size(), format, sap);
-
-  va_end(ap);
-  va_end(sap);
-
-  fputs(line.data(), stderr);
-#if defined(OS_WIN32)
-  OutputDebugStringA(line.data());
-#endif
-};
-
 void OptParse::usageDie(std::string const &message) {
   if (!message.empty()) {
-    print("error: %s\n", message.c_str());
+    Print("error: %s\n", message.c_str());
   }
 
-  print("usage: %s [%s] [%s] [%s] [%s]\n", "ds2", "RUN_MODE", "OPTIONS",
+  Print("usage: %s [%s] [%s] [%s] [%s]\n", "ds2", "RUN_MODE", "OPTIONS",
         "[HOST]:PORT", "-- PROGRAM [ARGUMENTS...]");
 
   size_t help_align = 0;
@@ -192,12 +174,12 @@ void OptParse::usageDie(std::string const &message) {
     if (e.second.hidden)
       continue;
 
-    print("  -%c, --%s", e.second.shortName, e.first.c_str());
-    print(" %s", (e.second.type == stringOption ? "ARG" : "   "));
+    Print("  -%c, --%s", e.second.shortName, e.first.c_str());
+    Print(" %s", (e.second.type == stringOption ? "ARG" : "   "));
     for (size_t i = 0; i < help_align - e.first.size(); ++i) {
-      print(" ");
+      Print(" ");
     }
-    print("%s\n", e.second.help.c_str());
+    Print("%s\n", e.second.help.c_str());
   }
 
   exit(EXIT_FAILURE);


### PR DESCRIPTION
These options are
DS2_HOST
DS2_PORT
DS2_RUN_MODE
DS2_PROGRAM

The addOption method from OptParse can now receive an optional envVarName.
The value from the env var is only used it the option hasn't been set
by the normal arguments, i.e. env vars have lower precedence.

The only bad thing is that DS2_RUN_MODE can only be used if no arguments
are passed. This is fixable... but it would be a major refactor that
might not be necessary

I tested it on both windows and linux, like this
<img width="831" alt="screen shot 2016-03-19 at 11 16 49 pm" src="https://cloud.githubusercontent.com/assets/1613874/13902818/b0449c8e-ee28-11e5-890f-d84d7414475a.png">
