### PR TITLE
Stack traces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,6 +205,7 @@ set(SUPPORT_COMMON_SOURCES
     Sources/MessageQueue.cpp
     Sources/SessionThread.cpp
     Sources/Support/Stringify.cpp
+    Sources/Utils/Backtrace.cpp
     Sources/Utils/Log.cpp
     Sources/Utils/OptParse.cpp
     Sources/Utils/Paths.cpp
@@ -293,9 +294,13 @@ endif ()
 add_subdirectory(Tools/JSObjects "${CMAKE_CURRENT_BINARY_DIR}/JSObjects")
 target_link_libraries(ds2 jsobjects)
 
-if (ANDROID)
-  target_link_libraries(ds2 log)
-endif ()
+if ("${OS_NAME}" MATCHES "Linux")
+  if (ANDROID)
+    target_link_libraries(ds2 log)
+  elseif (NOT TIZEN)
+    target_link_libraries(ds2 dl)
+  endif ()
+endif()
 
 if ("${OS_NAME}" MATCHES "FreeBSD")
   target_link_libraries(ds2 util procstat)

--- a/Headers/DebugServer2/Utils/Backtrace.h
+++ b/Headers/DebugServer2/Utils/Backtrace.h
@@ -1,0 +1,16 @@
+//
+// Copyright (c) 2014-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the University of Illinois/NCSA Open
+// Source License found in the LICENSE file in the root directory of this
+// source tree. An additional grant of patent rights can be found in the
+// PATENTS file in the same directory.
+//
+
+namespace ds2 {
+namespace Utils {
+
+void PrintBacktrace();
+}
+}

--- a/Sources/Support/POSIX/FaultHandler.cpp
+++ b/Sources/Support/POSIX/FaultHandler.cpp
@@ -9,6 +9,7 @@
 //
 
 #include "DebugServer2/Support/Stringify.h"
+#include "DebugServer2/Utils/Backtrace.h"
 #include "DebugServer2/Utils/Log.h"
 
 #include <cerrno>
@@ -28,7 +29,7 @@ private:
     DS2LOG(Error, "received %s with code %s at address %p, crashing",
            Stringify::Signal(si->si_signo),
            Stringify::SignalCode(si->si_signo, si->si_code), si->si_addr);
-
+    ds2::Utils::PrintBacktrace();
     _exit(si->si_signo);
   }
 

--- a/Sources/Utils/Backtrace.cpp
+++ b/Sources/Utils/Backtrace.cpp
@@ -1,0 +1,65 @@
+//
+// Copyright (c) 2014-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the University of Illinois/NCSA Open
+// Source License found in the LICENSE file in the root directory of this
+// source tree. An additional grant of patent rights can be found in the
+// PATENTS file in the same directory.
+//
+
+#include "DebugServer2/Utils/Log.h"
+
+#if defined(OS_DARWIN) || defined(__GLIBC__)
+#include <cxxabi.h>
+#include <dlfcn.h>
+#include <execinfo.h>
+#endif
+
+namespace ds2 {
+namespace Utils {
+
+#if defined(OS_DARWIN) || defined(__GLIBC__)
+void PrintBacktrace() {
+  static const int kStackSize = 100;
+  static void *stack[kStackSize];
+  int stackEntries = ::backtrace(stack, kStackSize);
+
+  for (int i = 0; i < stackEntries; ++i) {
+    static const int kPointerWidth = sizeof(void *) * 2;
+    Dl_info info;
+    int res;
+
+    res = ::dladdr(stack[i], &info);
+    if (res < 0) {
+      DS2LOG(Error, "%0#*" PRIxPTR, kPointerWidth,
+             reinterpret_cast<uintptr_t>(stack[i]));
+      continue;
+    }
+
+    char *demangled = nullptr;
+    const char *name;
+    if (info.dli_sname != nullptr) {
+      demangled = abi::__cxa_demangle(info.dli_sname, nullptr, nullptr, &res);
+      if (res == 0) {
+        name = demangled;
+      } else {
+        name = info.dli_sname;
+      }
+    } else {
+      name = "<NOT FOUND>";
+    }
+
+    DS2LOG(Error, "%0#*" PRIxPTR " %s+%#" PRIxPTR " (%s)", kPointerWidth,
+           reinterpret_cast<uintptr_t>(stack[i]), name,
+           static_cast<char *>(stack[i]) - static_cast<char *>(info.dli_saddr),
+           info.dli_fname);
+
+    ::free(demangled);
+  }
+}
+#else
+void PrintBacktrace() { DS2LOG(Warning, "unable to print backtrace"); }
+#endif
+}
+}

--- a/Sources/Utils/Log.cpp
+++ b/Sources/Utils/Log.cpp
@@ -10,6 +10,7 @@
 
 #include "DebugServer2/Utils/Log.h"
 #include "DebugServer2/Host/Platform.h"
+#include "DebugServer2/Utils/Backtrace.h"
 #include "DebugServer2/Utils/CompilerSupport.h"
 #include "DebugServer2/Utils/String.h"
 
@@ -147,8 +148,10 @@ void vLog(int level, char const *classname, char const *funcname,
   fputs(ss.str().c_str(), sOutputStream);
   fflush(sOutputStream);
 
-  if (level == kLogLevelFatal)
+  if (level == kLogLevelFatal) {
+    ds2::Utils::PrintBacktrace();
     abort();
+  }
 }
 
 void Log(int level, char const *classname, char const *funcname,


### PR DESCRIPTION
Output looks like this:
```
[2754761][PrintBacktrace] ERROR  : 0x000000004c717b ds2::Utils::PrintBacktrace()+0x17 (./ds2)
[2754761][PrintBacktrace] ERROR  : 0x000000004c7705 ds2::vLog(int, char const*, char const*, char const*, __va_list_tag*)+0x3d3 (./ds2)
[2754761][PrintBacktrace] ERROR  : 0x000000004c7886 ds2::Log(int, char const*, char const*, char const*, ...)+0xb1 (./ds2)
[2754761][PrintBacktrace] ERROR  : 0x000000004ce447 main+0x1925 (./ds2)
[2754761][PrintBacktrace] ERROR  : 0x007ff97b803b15 __libc_start_main+0xf5 (/lib64/libc.so.6)
[2754761][PrintBacktrace] ERROR  : 0x0000000049bc99 <NOT FOUND>+0x49bc99 (./ds2)
Aborted
```