### PR TITLE
Remove the status argument to `Process::wait`

### DIFF
--- a/Headers/DebugServer2/Target/Darwin/Process.h
+++ b/Headers/DebugServer2/Target/Darwin/Process.h
@@ -52,7 +52,7 @@ public:
   ErrorCode deallocateMemory(uint64_t address, size_t size) override;
 
 public:
-  ErrorCode wait(int *status = nullptr) override;
+  ErrorCode wait() override;
 
 public:
   Host::POSIX::PTrace &ptrace() const override;

--- a/Headers/DebugServer2/Target/FreeBSD/Process.h
+++ b/Headers/DebugServer2/Target/FreeBSD/Process.h
@@ -52,7 +52,7 @@ public:
   ErrorCode deallocateMemory(uint64_t address, size_t size) override;
 
 public:
-  ErrorCode wait(int *status = nullptr) override;
+  ErrorCode wait() override;
 
 public:
   Host::POSIX::PTrace &ptrace() const override;

--- a/Headers/DebugServer2/Target/Linux/Process.h
+++ b/Headers/DebugServer2/Target/Linux/Process.h
@@ -59,7 +59,7 @@ protected:
   ErrorCode checkMemoryErrorCode(uint64_t address);
 
 public:
-  ErrorCode wait(int *rstatus = nullptr) override;
+  ErrorCode wait() override;
 
 public:
   Host::POSIX::PTrace &ptrace() const override;

--- a/Headers/DebugServer2/Target/POSIX/Process.h
+++ b/Headers/DebugServer2/Target/POSIX/Process.h
@@ -53,7 +53,7 @@ public:
   void setSignalPass(int signo, bool set);
 
 public:
-  virtual ErrorCode wait(int *status = nullptr);
+  ErrorCode wait() override;
 
 public:
   virtual Host::POSIX::PTrace &ptrace() const = 0;

--- a/Headers/DebugServer2/Target/ProcessBase.h
+++ b/Headers/DebugServer2/Target/ProcessBase.h
@@ -106,6 +106,9 @@ public:
                               size_t length, size_t *nwritten = nullptr);
 
 public:
+  virtual ErrorCode wait() = 0;
+
+public:
   virtual ErrorCode allocateMemory(size_t size, uint32_t protection,
                                    uint64_t *address) = 0;
   virtual ErrorCode deallocateMemory(uint64_t address, size_t size) = 0;

--- a/Headers/DebugServer2/Target/Windows/Process.h
+++ b/Headers/DebugServer2/Target/Windows/Process.h
@@ -85,7 +85,7 @@ public:
   void setSignalPass(int signo, bool set) {}
 
 public:
-  ErrorCode wait(int *status = nullptr);
+  ErrorCode wait() override;
 
 public:
   static Target::Process *Create(Host::ProcessSpawner &spawner);

--- a/Sources/Target/Darwin/Process.cpp
+++ b/Sources/Target/Darwin/Process.cpp
@@ -44,11 +44,9 @@ Process::Process()
 Process::~Process() { terminate(); }
 
 ErrorCode Process::initialize(ProcessId pid, uint32_t flags) {
-  //
-  // Wait the main thread.
-  //
   int status;
 
+  // Wait the main thread.
   ErrorCode error = ptrace().wait(pid, &status);
   if (error != kSuccess)
     return error;
@@ -106,7 +104,7 @@ ErrorCode Process::attach(int waitStatus) {
   return kSuccess;
 }
 
-ErrorCode Process::wait(int *rstatus) {
+ErrorCode Process::wait() {
   int status, signal;
   ProcessInfo info;
   ErrorCode err;
@@ -116,20 +114,17 @@ ErrorCode Process::wait(int *rstatus) {
   DS2ASSERT(!_threads.empty());
 
 continue_waiting:
-  err = super::wait(&status);
+  err = ptrace().wait(_pid, &status);
   if (err != kSuccess)
     return err;
 
   DS2LOG(Debug, "stopped: status=%d", status);
 
   if (WIFEXITED(status)) {
-    err = super::wait(&status);
+    err = ptrace().wait(_pid, &status);
     DS2LOG(Debug, "exited: status=%d", status);
     _currentThread->updateStopInfo(status);
     _terminated = true;
-    if (rstatus != nullptr) {
-      *rstatus = status;
-    }
 
     return kSuccess;
   }
@@ -236,10 +231,6 @@ continue_waiting:
 
   if ((WIFEXITED(status) || WIFSIGNALED(status))) {
     _terminated = true;
-  }
-
-  if (rstatus != nullptr) {
-    *rstatus = status;
   }
 
   return kSuccess;

--- a/Sources/Target/Linux/Process.cpp
+++ b/Sources/Target/Linux/Process.cpp
@@ -148,7 +148,7 @@ ErrorCode Process::checkMemoryErrorCode(uint64_t address) {
   return kSuccess;
 }
 
-ErrorCode Process::wait(int *rstatus) {
+ErrorCode Process::wait() {
   int status, signal;
   ProcessInfo info;
   ThreadId tid;
@@ -286,10 +286,6 @@ ErrorCode Process::wait(int *rstatus) {
 
   if ((WIFEXITED(status) || WIFSIGNALED(status)) && tid == _pid) {
     _terminated = true;
-  }
-
-  if (rstatus != nullptr) {
-    *rstatus = status;
   }
 
   return kSuccess;

--- a/Sources/Target/POSIX/Process.cpp
+++ b/Sources/Target/POSIX/Process.cpp
@@ -92,7 +92,7 @@ ErrorCode Process::writeMemory(Address const &address, void const *data,
   return ptrace().writeMemory(_pid, address, data, length, count);
 }
 
-ErrorCode Process::wait(int *status) { return ptrace().wait(_pid, status); }
+ErrorCode Process::wait() { return ptrace().wait(_pid, nullptr); }
 
 ds2::Target::Process *Process::Attach(ProcessId pid) {
   if (pid <= 0)

--- a/Sources/Target/Windows/Process.cpp
+++ b/Sources/Target/Windows/Process.cpp
@@ -36,8 +36,7 @@ Process::~Process() { CloseHandle(_handle); }
 
 ErrorCode Process::initialize(ProcessId pid, HANDLE handle, ThreadId tid,
                               HANDLE threadHandle, uint32_t flags) {
-  int status;
-  ErrorCode error = wait(&status);
+  ErrorCode error = wait();
   if (error != kSuccess)
     return error;
 
@@ -155,7 +154,7 @@ ErrorCode Process::terminate() {
 
 bool Process::isAlive() const { return !_terminated; }
 
-ErrorCode Process::wait(int *status) {
+ErrorCode Process::wait() {
   if (_terminated)
     return kSuccess;
 


### PR DESCRIPTION
This also puts a definition of `wait` in `ProcessBase` and adds
`override` on all implementations in lower classes.