### PR TITLE
Remove depth: 1 from travis config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ branches:
     - master
 matrix:
   fast_finish: true
-git:
-  depth: 1
 
 env:
   - TARGET="Style"


### PR DESCRIPTION
This causes issues with builds that start after we do two pushes in a
row. Travis `git clone`s and then does a checkout of the git hash that
needs to be tested. If we do a clone with a depth of 1, only the HEAD
hash will be available.