### PR TITLE
Change log file flag from log-output to log-file, to match lldb-server

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,6 +205,7 @@ set(SUPPORT_COMMON_SOURCES
     Sources/MessageQueue.cpp
     Sources/SessionThread.cpp
     Sources/Support/Stringify.cpp
+    Sources/Utils/Backtrace.cpp
     Sources/Utils/Log.cpp
     Sources/Utils/OptParse.cpp
     Sources/Utils/Paths.cpp
@@ -293,9 +294,13 @@ endif ()
 add_subdirectory(Tools/JSObjects "${CMAKE_CURRENT_BINARY_DIR}/JSObjects")
 target_link_libraries(ds2 jsobjects)
 
-if (ANDROID)
-  target_link_libraries(ds2 log)
-endif ()
+if ("${OS_NAME}" MATCHES "Linux")
+  if (ANDROID)
+    target_link_libraries(ds2 log)
+  elseif (NOT TIZEN)
+    target_link_libraries(ds2 dl)
+  endif ()
+endif()
 
 if ("${OS_NAME}" MATCHES "FreeBSD")
   target_link_libraries(ds2 util procstat)

--- a/Headers/DebugServer2/Target/Darwin/Process.h
+++ b/Headers/DebugServer2/Target/Darwin/Process.h
@@ -52,7 +52,7 @@ public:
   ErrorCode deallocateMemory(uint64_t address, size_t size) override;
 
 public:
-  ErrorCode wait(int *status = nullptr) override;
+  ErrorCode wait() override;
 
 public:
   Host::POSIX::PTrace &ptrace() const override;

--- a/Headers/DebugServer2/Target/FreeBSD/Process.h
+++ b/Headers/DebugServer2/Target/FreeBSD/Process.h
@@ -52,7 +52,7 @@ public:
   ErrorCode deallocateMemory(uint64_t address, size_t size) override;
 
 public:
-  ErrorCode wait(int *status = nullptr) override;
+  ErrorCode wait() override;
 
 public:
   Host::POSIX::PTrace &ptrace() const override;

--- a/Headers/DebugServer2/Target/Linux/Process.h
+++ b/Headers/DebugServer2/Target/Linux/Process.h
@@ -59,7 +59,7 @@ protected:
   ErrorCode checkMemoryErrorCode(uint64_t address);
 
 public:
-  ErrorCode wait(int *rstatus = nullptr) override;
+  ErrorCode wait() override;
 
 public:
   Host::POSIX::PTrace &ptrace() const override;

--- a/Headers/DebugServer2/Target/POSIX/Process.h
+++ b/Headers/DebugServer2/Target/POSIX/Process.h
@@ -53,7 +53,7 @@ public:
   void setSignalPass(int signo, bool set);
 
 public:
-  virtual ErrorCode wait(int *status = nullptr);
+  ErrorCode wait() override;
 
 public:
   virtual Host::POSIX::PTrace &ptrace() const = 0;

--- a/Headers/DebugServer2/Target/ProcessBase.h
+++ b/Headers/DebugServer2/Target/ProcessBase.h
@@ -106,6 +106,9 @@ public:
                               size_t length, size_t *nwritten = nullptr);
 
 public:
+  virtual ErrorCode wait() = 0;
+
+public:
   virtual ErrorCode allocateMemory(size_t size, uint32_t protection,
                                    uint64_t *address) = 0;
   virtual ErrorCode deallocateMemory(uint64_t address, size_t size) = 0;

--- a/Headers/DebugServer2/Target/Windows/Process.h
+++ b/Headers/DebugServer2/Target/Windows/Process.h
@@ -85,7 +85,7 @@ public:
   void setSignalPass(int signo, bool set) {}
 
 public:
-  ErrorCode wait(int *status = nullptr);
+  ErrorCode wait() override;
 
 public:
   static Target::Process *Create(Host::ProcessSpawner &spawner);

--- a/Headers/DebugServer2/Utils/Backtrace.h
+++ b/Headers/DebugServer2/Utils/Backtrace.h
@@ -1,0 +1,16 @@
+//
+// Copyright (c) 2014-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the University of Illinois/NCSA Open
+// Source License found in the LICENSE file in the root directory of this
+// source tree. An additional grant of patent rights can be found in the
+// PATENTS file in the same directory.
+//
+
+namespace ds2 {
+namespace Utils {
+
+void PrintBacktrace();
+}
+}

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ usage: ds2 [RUN_MODE] [OPTIONS] [[HOST]:PORT] [-- PROGRAM [ARGUMENTS...]]
   -g, --gdb-compat           force ds2 to run in gdb compat mode
   -k, --keep-alive           keep the server alive after the client disconnects
   -L, --list-processes       list processes debuggable by the current user
-  -o, --log-output ARG       output log messages to the file specified
+  -o, --log-file ARG         output log messages to the file specified
   -N, --named-pipe ARG       determine a port dynamically and write back to FIFO
   -n, --no-colors            disable colored output
   -R, --reverse-connect      connect back to the debugger at [HOST]:PORT

--- a/Sources/Support/POSIX/FaultHandler.cpp
+++ b/Sources/Support/POSIX/FaultHandler.cpp
@@ -9,6 +9,7 @@
 //
 
 #include "DebugServer2/Support/Stringify.h"
+#include "DebugServer2/Utils/Backtrace.h"
 #include "DebugServer2/Utils/Log.h"
 
 #include <cerrno>
@@ -28,7 +29,7 @@ private:
     DS2LOG(Error, "received %s with code %s at address %p, crashing",
            Stringify::Signal(si->si_signo),
            Stringify::SignalCode(si->si_signo, si->si_code), si->si_addr);
-
+    ds2::Utils::PrintBacktrace();
     _exit(si->si_signo);
   }
 

--- a/Sources/Target/Darwin/Process.cpp
+++ b/Sources/Target/Darwin/Process.cpp
@@ -44,11 +44,9 @@ Process::Process()
 Process::~Process() { terminate(); }
 
 ErrorCode Process::initialize(ProcessId pid, uint32_t flags) {
-  //
-  // Wait the main thread.
-  //
   int status;
 
+  // Wait the main thread.
   ErrorCode error = ptrace().wait(pid, &status);
   if (error != kSuccess)
     return error;
@@ -106,7 +104,7 @@ ErrorCode Process::attach(int waitStatus) {
   return kSuccess;
 }
 
-ErrorCode Process::wait(int *rstatus) {
+ErrorCode Process::wait() {
   int status, signal;
   ProcessInfo info;
   ErrorCode err;
@@ -116,20 +114,17 @@ ErrorCode Process::wait(int *rstatus) {
   DS2ASSERT(!_threads.empty());
 
 continue_waiting:
-  err = super::wait(&status);
+  err = ptrace().wait(_pid, &status);
   if (err != kSuccess)
     return err;
 
   DS2LOG(Debug, "stopped: status=%d", status);
 
   if (WIFEXITED(status)) {
-    err = super::wait(&status);
+    err = ptrace().wait(_pid, &status);
     DS2LOG(Debug, "exited: status=%d", status);
     _currentThread->updateStopInfo(status);
     _terminated = true;
-    if (rstatus != nullptr) {
-      *rstatus = status;
-    }
 
     return kSuccess;
   }
@@ -236,10 +231,6 @@ continue_waiting:
 
   if ((WIFEXITED(status) || WIFSIGNALED(status))) {
     _terminated = true;
-  }
-
-  if (rstatus != nullptr) {
-    *rstatus = status;
   }
 
   return kSuccess;

--- a/Sources/Target/Linux/Process.cpp
+++ b/Sources/Target/Linux/Process.cpp
@@ -148,7 +148,7 @@ ErrorCode Process::checkMemoryErrorCode(uint64_t address) {
   return kSuccess;
 }
 
-ErrorCode Process::wait(int *rstatus) {
+ErrorCode Process::wait() {
   int status, signal;
   ProcessInfo info;
   ThreadId tid;
@@ -286,10 +286,6 @@ ErrorCode Process::wait(int *rstatus) {
 
   if ((WIFEXITED(status) || WIFSIGNALED(status)) && tid == _pid) {
     _terminated = true;
-  }
-
-  if (rstatus != nullptr) {
-    *rstatus = status;
   }
 
   return kSuccess;

--- a/Sources/Target/POSIX/Process.cpp
+++ b/Sources/Target/POSIX/Process.cpp
@@ -92,7 +92,7 @@ ErrorCode Process::writeMemory(Address const &address, void const *data,
   return ptrace().writeMemory(_pid, address, data, length, count);
 }
 
-ErrorCode Process::wait(int *status) { return ptrace().wait(_pid, status); }
+ErrorCode Process::wait() { return ptrace().wait(_pid, nullptr); }
 
 ds2::Target::Process *Process::Attach(ProcessId pid) {
   if (pid <= 0)

--- a/Sources/Target/POSIX/Thread.cpp
+++ b/Sources/Target/POSIX/Thread.cpp
@@ -32,7 +32,6 @@ ErrorCode Thread::updateStopInfo(int waitStatus) {
     _stopInfo.status = WEXITSTATUS(waitStatus);
   } else if (WIFSIGNALED(waitStatus)) {
     _stopInfo.event = StopInfo::kEventKill;
-    _stopInfo.status = WEXITSTATUS(waitStatus);
     _stopInfo.signal = WTERMSIG(waitStatus);
   } else if (WIFSTOPPED(waitStatus)) {
     _stopInfo.event = StopInfo::kEventStop;

--- a/Sources/Target/Windows/Process.cpp
+++ b/Sources/Target/Windows/Process.cpp
@@ -36,8 +36,7 @@ Process::~Process() { CloseHandle(_handle); }
 
 ErrorCode Process::initialize(ProcessId pid, HANDLE handle, ThreadId tid,
                               HANDLE threadHandle, uint32_t flags) {
-  int status;
-  ErrorCode error = wait(&status);
+  ErrorCode error = wait();
   if (error != kSuccess)
     return error;
 
@@ -155,7 +154,7 @@ ErrorCode Process::terminate() {
 
 bool Process::isAlive() const { return !_terminated; }
 
-ErrorCode Process::wait(int *status) {
+ErrorCode Process::wait() {
   if (_terminated)
     return kSuccess;
 

--- a/Sources/Utils/Backtrace.cpp
+++ b/Sources/Utils/Backtrace.cpp
@@ -1,0 +1,65 @@
+//
+// Copyright (c) 2014-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the University of Illinois/NCSA Open
+// Source License found in the LICENSE file in the root directory of this
+// source tree. An additional grant of patent rights can be found in the
+// PATENTS file in the same directory.
+//
+
+#include "DebugServer2/Utils/Log.h"
+
+#if defined(OS_DARWIN) || defined(__GLIBC__)
+#include <cxxabi.h>
+#include <dlfcn.h>
+#include <execinfo.h>
+#endif
+
+namespace ds2 {
+namespace Utils {
+
+#if defined(OS_DARWIN) || defined(__GLIBC__)
+void PrintBacktrace() {
+  static const int kStackSize = 100;
+  static void *stack[kStackSize];
+  int stackEntries = ::backtrace(stack, kStackSize);
+
+  for (int i = 0; i < stackEntries; ++i) {
+    static const int kPointerWidth = sizeof(void *) * 2;
+    Dl_info info;
+    int res;
+
+    res = ::dladdr(stack[i], &info);
+    if (res < 0) {
+      DS2LOG(Error, "%0#*" PRIxPTR, kPointerWidth,
+             reinterpret_cast<uintptr_t>(stack[i]));
+      continue;
+    }
+
+    char *demangled = nullptr;
+    const char *name;
+    if (info.dli_sname != nullptr) {
+      demangled = abi::__cxa_demangle(info.dli_sname, nullptr, nullptr, &res);
+      if (res == 0) {
+        name = demangled;
+      } else {
+        name = info.dli_sname;
+      }
+    } else {
+      name = "<NOT FOUND>";
+    }
+
+    DS2LOG(Error, "%0#*" PRIxPTR " %s+%#" PRIxPTR " (%s)", kPointerWidth,
+           reinterpret_cast<uintptr_t>(stack[i]), name,
+           static_cast<char *>(stack[i]) - static_cast<char *>(info.dli_saddr),
+           info.dli_fname);
+
+    ::free(demangled);
+  }
+}
+#else
+void PrintBacktrace() { DS2LOG(Warning, "unable to print backtrace"); }
+#endif
+}
+}

--- a/Sources/Utils/Log.cpp
+++ b/Sources/Utils/Log.cpp
@@ -10,6 +10,7 @@
 
 #include "DebugServer2/Utils/Log.h"
 #include "DebugServer2/Host/Platform.h"
+#include "DebugServer2/Utils/Backtrace.h"
 #include "DebugServer2/Utils/CompilerSupport.h"
 #include "DebugServer2/Utils/String.h"
 
@@ -147,8 +148,10 @@ void vLog(int level, char const *classname, char const *funcname,
   fputs(ss.str().c_str(), sOutputStream);
   fflush(sOutputStream);
 
-  if (level == kLogLevelFatal)
+  if (level == kLogLevelFatal) {
+    ds2::Utils::PrintBacktrace();
     abort();
+  }
 }
 
 void Log(int level, char const *classname, char const *funcname,

--- a/Sources/main.cpp
+++ b/Sources/main.cpp
@@ -271,7 +271,7 @@ int main(int argc, char **argv) {
   bool reverse = false;
 
   // Logging options.
-  opts.addOption(ds2::OptParse::stringOption, "log-output", 'o',
+  opts.addOption(ds2::OptParse::stringOption, "log-file", 'o',
                  "output log messages to the file specified");
   opts.addOption(ds2::OptParse::boolOption, "debug-remote", 'D',
                  "enable log for remote protocol packets");
@@ -329,11 +329,11 @@ int main(int argc, char **argv) {
   argc -= idx, argv += idx;
 
   // Logging options.
-  if (!opts.getString("log-output").empty()) {
-    FILE *stream = fopen(opts.getString("log-output").c_str(), "a");
+  if (!opts.getString("log-file").empty()) {
+    FILE *stream = fopen(opts.getString("log-file").c_str(), "a");
     if (stream == nullptr) {
       DS2LOG(Error, "unable to open %s for writing: %s",
-             opts.getString("log-output").c_str(), strerror(errno));
+             opts.getString("log-file").c_str(), strerror(errno));
     } else {
 #if !defined(OS_WIN32)
       // When ds2 is spawned by an app (e.g.: on Android), it will run with the

--- a/Support/Scripts/prepare-android-toolchain.sh
+++ b/Support/Scripts/prepare-android-toolchain.sh
@@ -65,15 +65,18 @@ case "$1" in
     ;;
 esac
 
+# gcc version isn't guaranteed to match toolchain version - for example, 4.9 vs 4.9.x
+gcc_version="$( "${toolchain_path}/bin/${toolchain_triple}-gcc" --version | awk 'NR==1{print $3}' )"
+
 # Copy C++ stuff
-clobber_dir "${aosp_ndk_path}/current/sources/cxx-stl/gnu-libstdc++/${toolchain_version}/include" "${toolchain_path}/include/c++/${toolchain_version}"
+clobber_dir "${aosp_ndk_path}/current/sources/cxx-stl/gnu-libstdc++/${toolchain_version}/include" "${toolchain_path}/include/c++/${gcc_version}"
 copy_cpp_binaries() {
   clobber_dir "${aosp_ndk_path}/current/sources/cxx-stl/gnu-libstdc++/${toolchain_version}/libs/$1/libgnustl_static.a" "${toolchain_path}/${toolchain_triple}/$2/libstdc++.a"
   clobber_dir "${aosp_ndk_path}/current/sources/cxx-stl/gnu-libstdc++/${toolchain_version}/libs/$1/libgnustl_shared.so" "${toolchain_path}/${toolchain_triple}/$2/libgnustl_shared.so"
   clobber_dir "${aosp_ndk_path}/current/sources/cxx-stl/gnu-libstdc++/${toolchain_version}/libs/$1/libsupc++.a" "${toolchain_path}/${toolchain_triple}/$2/libsupc++.a"
 }
 copy_cpp_bits() {
-  clobber_dir "${aosp_ndk_path}/current/sources/cxx-stl/gnu-libstdc++/${toolchain_version}/libs/$1/include/bits" "${toolchain_path}/include/c++/${toolchain_version}/${toolchain_triple}/$2"
+  clobber_dir "${aosp_ndk_path}/current/sources/cxx-stl/gnu-libstdc++/${toolchain_version}/libs/$1/include/bits" "${toolchain_path}/include/c++/${gcc_version}/${toolchain_triple}/$2"
 }
 case "$1" in
   "aarch64")


### PR DESCRIPTION
This allows us to set the log file when the debugserver is spawned by lldb, by using the
environment variable 'LLDB_DEBUGSERVER_LOG_FILE'