### PR TITLE
Add a `--fast` option to run-lldb-tests.sh.

### DIFF
--- a/Support/Scripts/run-lldb-tests.sh
+++ b/Support/Scripts/run-lldb-tests.sh
@@ -24,60 +24,67 @@ source "$top/Support/Scripts/common.sh"
 [ "$(uname)" == "Linux" ] || die "The lldb test suite requires a Linux host environment."
 [ -x "$build_dir/ds2" ]   || die "Unable to find a ds2 binary in the current directory."
 
+if [ $# -ge 1 ] && [ "$1" = "--fast" ]; then
+  test_only=true
+else
+  test_only=false
+fi
+
 if [ -s "/etc/centos-release" ]; then
   llvm_path="$build_dir/llvm"
-  git_clone "$REPO_BASE/llvm.git"  "$llvm_path"             "$UPSTREAM_BRANCH"
-  git_clone "$REPO_BASE/lldb.git"  "$llvm_path/tools/lldb"  "$UPSTREAM_BRANCH"
-  git_clone "$REPO_BASE/clang.git" "$llvm_path/tools/clang" "$UPSTREAM_BRANCH"
-
   llvm_build="$llvm_path/build"
-  mkdir -p "$llvm_build"
-  cd "$llvm_build"
-  if [ ! -f "$llvm_build/build.ninja" ]; then
-    cmake .. -G Ninja
-  fi
-  ninja
-
+  lldb_path="$llvm_path/tools/lldb"
+  lldb_exe="$llvm_build/bin/lldb"
+  cc_exe="$(which gcc)"
   export PYTHONPATH="$llvm_build/lib64/python2.7/site-packages"
 
-  patch -d "$llvm_path/tools/lldb" -p1 <"$top/Support/Testing/Pythonpath-hack.patch"
+  if ! $test_only; then
+    git_clone "$REPO_BASE/llvm.git"  "$llvm_path"             "$UPSTREAM_BRANCH"
+    git_clone "$REPO_BASE/lldb.git"  "$llvm_path/tools/lldb"  "$UPSTREAM_BRANCH"
+    git_clone "$REPO_BASE/clang.git" "$llvm_path/tools/clang" "$UPSTREAM_BRANCH"
 
-  lldb_exe="$llvm_build/bin/lldb"
-  lldb_path="$llvm_path/tools/lldb"
-  cc_exe="$(which gcc)"
+    mkdir -p "$llvm_build"
+    cd "$llvm_build"
+    cmake .. -G Ninja
+    ninja
+
+    patch -d "$llvm_path/tools/lldb" -p1 <"$top/Support/Testing/Pythonpath-hack.patch"
+  fi
 elif grep -q "Ubuntu" "/etc/issue"; then
   lldb_path="$build_dir/lldb"
-  git_clone "$REPO_BASE/lldb.git" "$lldb_path" "$UPSTREAM_BRANCH"
-
+  lldb_exe="$(which lldb-3.7)"
+  cc_exe="$(which gcc-5)"
   python_base="$build_dir/lib"
-
   export LD_LIBRARY_PATH=$python_base
   export PYTHONPATH="$python_base/python2.7/site-packages"
 
-  # Sync lldb libs to local build dir
-  rsync -a /usr/lib/x86_64-linux-gnu/       "$python_base"
-  rsync -a /usr/lib/llvm-3.7/lib/python2.7/ "$python_base/python2.7"
-  rsync -a "$python_base/liblldb-3.7.so"    "$python_base/liblldb.so"
+  if ! $test_only; then
+    git_clone "$REPO_BASE/lldb.git" "$lldb_path" "$UPSTREAM_BRANCH"
 
-  # Fix broken python lldb symlinks
-  cd "$PYTHONPATH/lldb"
-  for path in $( ls *.so* ); do
-    new_link="$(readlink "$path" | sed 's,x86_64-linux-gnu/,,g')"
-    rm "$path"
-    ln -s "$new_link" "$path"
-  done
+    # Sync lldb libs to local build dir
+    rsync -a /usr/lib/x86_64-linux-gnu/       "$python_base"
+    rsync -a /usr/lib/llvm-3.7/lib/python2.7/ "$python_base/python2.7"
+    rsync -a "$python_base/liblldb-3.7.so"    "$python_base/liblldb.so"
 
-  lldb_exe="$(which lldb-3.7)"
-  cc_exe="$(which gcc-5)"
+    # Fix broken python lldb symlinks
+    cd "$PYTHONPATH/lldb"
+    for path in $( ls *.so* ); do
+      new_link="$(readlink "$path" | sed 's,x86_64-linux-gnu/,,g')"
+      rm "$path"
+      ln -s "$new_link" "$path"
+    done
+  fi
 else
   die "Testing is only supported on CentOS and Ubuntu."
 fi
 
-testPath="$top/Support/Testing"
-for p in $testPath/Patches/*.patch ; do
-  echo "Applying $p"
-  patch -d "$lldb_path" -p1 <"$p"
-done
+if ! $test_only; then
+  testPath="$top/Support/Testing"
+  for p in $testPath/Patches/*.patch ; do
+    echo "Applying $p"
+    patch -d "$lldb_path" -p1 <"$p"
+  done
+fi
 
 cd "$lldb_path/test"
 args="-q --executable "$lldb_exe" -u CXXFLAGS -u CFLAGS -C $cc_exe -m"


### PR DESCRIPTION
This basically just runs the test. It doesn't try to build lldb, or
patch the tests, or anything. It's meant to be used by developers, after
the first run of run-lldb-tests.