### PR TITLE
Forward data from OutputDebugString to the debugger.

### DIFF
--- a/Headers/DebugServer2/Types.h
+++ b/Headers/DebugServer2/Types.h
@@ -114,6 +114,7 @@ struct StopInfo {
     kReasonMathError,
     kReasonInstructionError,
     kReasonLibraryEvent,
+    kReasonDebugOutput,
 #endif
   };
 

--- a/Sources/GDBRemote/Structures.cpp
+++ b/Sources/GDBRemote/Structures.cpp
@@ -230,6 +230,7 @@ std::string StopInfo::encodeInfo(CompatibilityMode mode,
   case StopInfo::kReasonMemoryAlignment:
   case StopInfo::kReasonMathError:
   case StopInfo::kReasonInstructionError:
+  case StopInfo::kReasonDebugOutput:
 #endif
     break;
   }

--- a/Sources/Target/Windows/Thread.cpp
+++ b/Sources/Target/Windows/Thread.cpp
@@ -235,7 +235,7 @@ void Thread::updateState(DEBUG_EVENT const &de) {
   case OUTPUT_DEBUG_STRING_EVENT:
     _state = kStopped;
     _stopInfo.event = StopInfo::kEventStop;
-    _stopInfo.reason = StopInfo::kReasonNone;
+    _stopInfo.reason = StopInfo::kReasonDebugOutput;
     break;
 
   default:


### PR DESCRIPTION
This commit contains a seemingly useless switch on the stop reason but
this will be used in later commits to implement automatic continue of
other types of stops, for instance thread creation, etc.