### PR TITLE
Use absolute paths for library names in svr4 packets when possible

### DIFF
--- a/Sources/GDBRemote/DebugSessionImpl.cpp
+++ b/Sources/GDBRemote/DebugSessionImpl.cpp
@@ -552,7 +552,7 @@ ErrorCode DebugSessionImpl::onXferRead(Session &session,
           mainMapAddress = library.svr4.mapAddress;
         } else {
           sslibs << "<library "
-                 << "name=\"" << ds2::Utils::Basename(library.path) << "\" "
+                 << "name=\"" << library.path << "\" "
                  << "lm=\""
                  << "0x" << std::hex << library.svr4.mapAddress << "\" "
                  << "l_addr=\""


### PR DESCRIPTION
NOTE: This may cause library duplication on Tizen in some cases without this lldb patch - http://reviews.llvm.org/D19557.