### PR TITLE
Handle uncaught Win COM exceptions

### DIFF
--- a/Headers/DebugServer2/Host/Windows/ExtraWrappers.h
+++ b/Headers/DebugServer2/Host/Windows/ExtraWrappers.h
@@ -17,6 +17,7 @@
 #include <cstdio>
 #include <windows.h>
 
+#define DS2_EXCEPTION_UNCAUGHT_COM 0x800706BA
 #define DS2_EXCEPTION_UNCAUGHT_USER 0xE06D7363
 
 // Some APIs are not exposed when building for UAP.

--- a/Sources/Support/Windows/Stringify.cpp
+++ b/Sources/Support/Windows/Stringify.cpp
@@ -54,6 +54,8 @@ char const *Stringify::ExceptionCode(DWORD code) {
     DO_STRINGIFY(EXCEPTION_PRIV_INSTRUCTION)
     DO_STRINGIFY(EXCEPTION_SINGLE_STEP)
     DO_STRINGIFY(EXCEPTION_STACK_OVERFLOW)
+  case DS2_EXCEPTION_UNCAUGHT_COM:
+    return "0x800706BA (uncaught COM exception)";
   case DS2_EXCEPTION_UNCAUGHT_USER:
     return "0xE06D7363 (uncaught user exception)";
     DO_DEFAULT("unknown exception code", code)

--- a/Sources/Target/Windows/Thread.cpp
+++ b/Sources/Target/Windows/Thread.cpp
@@ -151,6 +151,7 @@ void Thread::updateState(DEBUG_EVENT const &de) {
 
     case EXCEPTION_INVALID_DISPOSITION:
     case EXCEPTION_NONCONTINUABLE_EXCEPTION:
+    case DS2_EXCEPTION_UNCAUGHT_COM:
     case DS2_EXCEPTION_UNCAUGHT_USER:
       _stopInfo.event = StopInfo::kEventStop;
       _stopInfo.reason = StopInfo::kReasonInstructionError;


### PR DESCRIPTION
Sadly it's very hard to know reasons behind this kind of COM exceptions,
but we can just skip.