### PR TITLE
Fix writeCPUState on Windows.

### DIFF
--- a/Headers/DebugServer2/Architecture/X86/RegisterCopy.h
+++ b/Headers/DebugServer2/Architecture/X86/RegisterCopy.h
@@ -23,6 +23,10 @@ namespace X86 {
 #define _PASTE(A, B) A##B
 #define PASTE(A, B) _PASTE(A, B)
 
+#define DO_EMPTY()                                                             \
+  do {                                                                         \
+  } while (0)
+
 #define DO_COPY_GPR_32()                                                       \
   do {                                                                         \
     DO_COPY_GP_REG(ax);                                                        \
@@ -85,8 +89,8 @@ namespace X86 {
     DO_COPY_REG(state.linux_gp.gs_base, user.gs_base, 0);                      \
   } while (0)
 #else
-#define DO_COPY_EXTRA_32()
-#define DO_COPY_EXTRA_64()
+#define DO_COPY_EXTRA_32() DO_EMPTY()
+#define DO_COPY_EXTRA_64() DO_EMPTY()
 #endif
 
 #if defined(OS_LINUX) && defined(ARCH_X86)

--- a/Headers/DebugServer2/Architecture/X86/RegisterCopy.h
+++ b/Headers/DebugServer2/Architecture/X86/RegisterCopy.h
@@ -132,7 +132,6 @@ static inline void user_to_state32(StateType &state,
 template <typename UserStructType, typename StateType>
 static inline void state32_to_user(UserStructType &user,
                                    StateType const &state) {
-  std::memset(&user, 0, sizeof(user));
   DO_COPY_GPR_32();
   DO_COPY_SS();
   DO_COPY_EXTRA_32();
@@ -155,7 +154,6 @@ static inline void user_to_state64(StateType &state,
 template <typename UserStructType, typename StateType>
 static inline void state64_to_user(UserStructType &user,
                                    StateType const &state) {
-  std::memset(&user, 0, sizeof(user));
   DO_COPY_GPR_64();
   DO_COPY_SS();
   DO_COPY_EXTRA_64();

--- a/Sources/Target/Windows/X86/ThreadX86.cpp
+++ b/Sources/Target/Windows/X86/ThreadX86.cpp
@@ -47,7 +47,7 @@ ErrorCode Thread::step(int signal, Address const &address) {
 ErrorCode Thread::readCPUState(Architecture::CPUState &state) {
   CONTEXT context;
 
-  memset(&context, 0, sizeof(context));
+  std::memset(&context, 0, sizeof(context));
   // TODO(sas): Handle AVX.
   context.ContextFlags = CONTEXT_INTEGER |            // GP registers.
                          CONTEXT_CONTROL |            // Some more GP + cs/ss.
@@ -102,7 +102,7 @@ ErrorCode Thread::readCPUState(Architecture::CPUState &state) {
 ErrorCode Thread::writeCPUState(Architecture::CPUState const &state) {
   CONTEXT context;
 
-  memset(&context, 0, sizeof(context));
+  std::memset(&context, 0, sizeof(context));
   // TODO(sas): Handle floats, SSE, AVX and debug registers.
   context.ContextFlags = CONTEXT_INTEGER | // GP registers.
                          CONTEXT_CONTROL | // Some more GP + cs/ss.


### PR DESCRIPTION
Incorrect `memset` after the last magical macro patch.