### PR TITLE
Print the diff created by clang-format

### DIFF
--- a/Support/Testing/Travis/script.sh
+++ b/Support/Testing/Travis/script.sh
@@ -71,6 +71,8 @@ check_dirty() {
     for f in "${dirty[@]}"; do
       echo "dirty: $f"
     done
+    echo "Here is the diff:"
+    git --no-pager diff
     exit 1
   fi
 }


### PR DESCRIPTION
I did this patch because I couldn't get my hands on a clang-format 3.8. brew propose me 3.7.1 or 3.9, even on a linux vm I have, getting the correction version is painful.

Even if you are using the same style "LLVM", all the different version of clang-format disagree on the final output. In my case, 3.9 force me to reorder some of my header, when 3.8 want the header in an other order. This is just frustrating.

So here what I'm proposing is to print the defect found in the test rather than just giving the name of the file.

<3
