### PR TITLE
Fix compilation error on freebsd build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,7 +285,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang"
   if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND NOT "${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS "5.1")
     target_compile_options(ds2 PRIVATE -Wsuggest-override)
   endif ()
-  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND NOT "${CMAKE_CXX_COMPILER_VERSION}" VERSION_LESS "3.5")
     target_compile_options(ds2 PRIVATE -Winconsistent-missing-override)
   endif ()
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")

--- a/Sources/Host/FreeBSD/ProcStat.cpp
+++ b/Sources/Host/FreeBSD/ProcStat.cpp
@@ -8,14 +8,16 @@
 // PATENTS file in the same directory.
 //
 
-#include <libprocstat.h>
-#include <libutil.h>
 #include <string>
 #include <sys/elf.h>
 #include <sys/param.h>
 #include <sys/sysctl.h>
 #include <sys/types.h>
 #include <sys/user.h>
+// clang-format off
+#include <libprocstat.h>
+#include <libutil.h>
+// clang-format on
 
 #include "DebugServer2/Host/FreeBSD/ProcStat.h"
 #include "DebugServer2/Support/POSIX/ELFSupport.h"

--- a/Sources/Target/FreeBSD/Process.cpp
+++ b/Sources/Target/FreeBSD/Process.cpp
@@ -201,8 +201,7 @@ continue_waiting:
 
   switch (_currentThread->_stopInfo.event) {
   case StopInfo::kEventNone:
-    switch (_currentThread->_stopInfo.reason) {
-    case StopInfo::kReasonNone:
+    if (_currentThread->_stopInfo.reason == StopInfo::kReasonNone) {
       ptrace().resume(ProcessThreadId(_pid, tid), info);
       goto continue_waiting;
     }


### PR DESCRIPTION
freebsd 10.1 have clang 3.4.1 by default and this doesn't sound to manage the flag inconsistent-missing-override. Since freebsd is compile with clang, not sure we want to force the simple user to upgrade clang version :-D

The other are just simple compilation fixes.