### PR TITLE
Fix Fix-Timeout.patch to print all output

### DIFF
--- a/Support/Testing/Patches/Fix-Timeout.patch
+++ b/Support/Testing/Patches/Fix-Timeout.patch
@@ -2,7 +2,7 @@ diff --git a/test/dosep.py b/test/dosep.py
 index fb1a5bd..6853f55 100755
 --- a/test/dosep.py
 +++ b/test/dosep.py
-@@ -123,7 +123,30 @ def call_with_timeout(command, timeout, name):
+@@ -123,7 +123,28 @ def call_with_timeout(command, timeout, name):
          process = subprocess.Popen(command, stdin=subprocess.PIPE,
                                              stdout=subprocess.PIPE,
                                              stderr=subprocess.PIPE)
@@ -15,7 +15,7 @@ index fb1a5bd..6853f55 100755
 +        suite = ' (Running suite: ' + suite + ')                    '
 +        sys.stderr.write(suite)
 +        
-+    output = []
++    output = ['stdout not read', '']
 +    name = ''
 +    for arg in command:
 +        if 'Test' in arg:
@@ -23,14 +23,12 @@ index fb1a5bd..6853f55 100755
 +    update_print(name)
 +    while True:
 +        line = process.stderr.readline()
-+        output.append(line)
++        output[1] += line
 +        if line == '' and process.poll() is not None:
 +            break
 +        if 'PASS:' in line or 'FAIL:' in line:
 +            print '\r' + line,
 +            update_print(name)
-+        elif 'RESULT:' in line:
-+            output = [line]
      exit_status = process.returncode
      passes, failures = parse_test_results(output)
      update_status(name, command, output if exit_status != 0 else None)


### PR DESCRIPTION
This is not the cleanest version possible, but it works and it's really close to what we have for the moment.

I did try a lot of different version, but all hung something for different reason, it's just weird. 