### PR TITLE
Make array_sizeof work with CPUState structures.

### DIFF
--- a/Headers/DebugServer2/Architecture/ARM/CPUState.h
+++ b/Headers/DebugServer2/Architecture/ARM/CPUState.h
@@ -108,13 +108,13 @@ public:
 public:
   inline void getGPState(GPRegisterValueVector &regs) const {
     regs.clear();
-    for (size_t n = 0; n < array_size(gp.regs); n++) {
+    for (size_t n = 0; n < array_sizeof(gp.regs); n++) {
       regs.push_back(GPRegisterValue{sizeof(gp.regs[n]), gp.regs[n]});
     }
   }
 
   inline void setGPState(std::vector<uint64_t> const &regs) {
-    for (size_t n = 0; n < regs.size() && n < array_size(gp.regs); n++) {
+    for (size_t n = 0; n < regs.size() && n < array_sizeof(gp.regs); n++) {
       gp.regs[n] = regs[n];
     }
   }

--- a/Headers/DebugServer2/Architecture/ARM64/CPUState.h
+++ b/Headers/DebugServer2/Architecture/ARM64/CPUState.h
@@ -67,13 +67,13 @@ struct CPUState64 {
 public:
   inline void getGPState(GPRegisterValueVector &regs) const {
     regs.clear();
-    for (size_t n = 0; n < array_size(gp.regs); n++) {
+    for (size_t n = 0; n < array_sizeof(gp.regs); n++) {
       regs.push_back(GPRegisterValue{sizeof(gp.regs[n]), gp.regs[n]});
     }
   }
 
   inline void setGPState(std::vector<uint64_t> const &regs) {
-    for (size_t n = 0; n < regs.size() && n < array_size(gp.regs); n++) {
+    for (size_t n = 0; n < regs.size() && n < array_sizeof(gp.regs); n++) {
       gp.regs[n] = regs[n];
     }
   }


### PR DESCRIPTION
This actually renames array_size to array_sizeof also.