### PR TITLE
Force BP size to 2 on Windows ARM.

### DIFF
--- a/Sources/Architecture/ARM/SoftwareBreakpointManager.cpp
+++ b/Sources/Architecture/ARM/SoftwareBreakpointManager.cpp
@@ -113,6 +113,16 @@ bool SoftwareBreakpointManager::hit(Target::Thread *thread) {
 
 void SoftwareBreakpointManager::getOpcode(uint32_t type,
                                           std::string &opcode) const {
+#if defined(OS_WIN32) && defined(ARCH_ARM)
+  if (type == 4) {
+    static const uint32_t WinARMBPType = 2;
+    DS2LOG(Warning, "requesting a breakpoint of size %u on Windows ARM, "
+                    "adjusting to type %u",
+           type, WinARMBPType);
+    type = WinARMBPType;
+  }
+#endif
+
   switch (type) {
 #if defined(ARCH_ARM)
   case 2: // udf #1


### PR DESCRIPTION
Windows ARM (more precisely, WinPhone ARM) is a pure thumb environment,
so if the debugger is requesting a breakpoint of size 4, it's probably
an older/buggy version and we should enforce size 2.