### PR TITLE
Fix incorrect ARM CPUState register definition.

### DIFF
--- a/Headers/DebugServer2/Architecture/ARM/CPUState.h
+++ b/Headers/DebugServer2/Architecture/ARM/CPUState.h
@@ -53,7 +53,7 @@ struct CPUState {
   union {
     uint32_t regs[16 + 1];
     struct {
-      uint32_t r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, sp, ip, lr, pc,
+      uint32_t r0, r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, ip, sp, lr, pc,
           cpsr;
     };
   } gp;


### PR DESCRIPTION
ip and sp were swapped. This worked fine on Linux because we didn't use
the named registers directly.