### PR TITLE
Don't use unnecessary unique ptr in platform mode

### DIFF
--- a/Headers/DebugServer2/GDBRemote/SessionBase.h
+++ b/Headers/DebugServer2/GDBRemote/SessionBase.h
@@ -34,7 +34,7 @@ protected:
 
 public:
   SessionBase(CompatibilityMode mode);
-  virtual ~SessionBase();
+  virtual ~SessionBase() = default;
 
 public:
   CompatibilityMode mode() const { return _compatMode; };

--- a/Sources/GDBRemote/SessionBase.cpp
+++ b/Sources/GDBRemote/SessionBase.cpp
@@ -30,8 +30,6 @@ SessionBase::SessionBase(CompatibilityMode mode)
   _interpreter.setSession(this);
 }
 
-SessionBase::~SessionBase() { delete _channel; }
-
 bool SessionBase::create(Host::Channel *channel) {
   if (_channel != nullptr || channel == nullptr)
     return false;

--- a/Sources/main.cpp
+++ b/Sources/main.cpp
@@ -105,11 +105,11 @@ static int PlatformMain(std::string const &host, std::string const &port) {
 static int RunDebugServer(Socket *socket, SessionDelegate *impl) {
   Session session(gGDBCompat ? ds2::GDBRemote::kCompatibilityModeGDB
                              : ds2::GDBRemote::kCompatibilityModeLLDB);
-  auto qchannel = new QueueChannel(socket);
-  SessionThread thread(qchannel, &session);
+  auto qchannel = std::unique_ptr<QueueChannel>(new QueueChannel(socket));
+  SessionThread thread(qchannel.get(), &session);
 
   session.setDelegate(impl);
-  session.create(qchannel);
+  session.create(qchannel.get());
 
   DS2LOG(Debug, "DEBUG SERVER STARTED");
   thread.start();


### PR DESCRIPTION
The destructor for SessionBase will always free its channel in
the destructor, prevent double-frees