### PR TITLE
Skip some function declarations when running doxygen.

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -2018,7 +2018,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             =
+PREDEFINED             = DOXYGEN
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/Headers/DebugServer2/Host/Linux/ExtraWrappers.h
+++ b/Headers/DebugServer2/Host/Linux/ExtraWrappers.h
@@ -20,6 +20,8 @@
 #include <sys/user.h>
 #include <unistd.h>
 
+#if !defined(DOXYGEN)
+
 // Required structs for PTrace GETREGSET with NT_X86_STATE
 // These structs are not made available by the system headers
 struct YMMHighVector {
@@ -72,5 +74,7 @@ static inline int tkill(pid_t tid, int signo) {
 #if !defined(TRAP_HWBKPT)
 #define TRAP_HWBKPT 4
 #endif
+
+#endif // !DOXYGEN
 
 #endif // !__DebugServer2_Host_Linux_ExtraWrappers_h

--- a/Headers/DebugServer2/Host/Windows/ExtraWrappers.h
+++ b/Headers/DebugServer2/Host/Windows/ExtraWrappers.h
@@ -24,6 +24,8 @@
 // Some APIs are not exposed when building for UAP.
 #if !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 
+#if !defined(DOXYGEN)
+
 // clang-format off
 extern "C" {
 
@@ -412,6 +414,8 @@ WINBASEAPI LPTOP_LEVEL_EXCEPTION_FILTER WINAPI SetUnhandledExceptionFilter(
 );
 } // extern "C"
 // clang-format on
+
+#endif // !DOXYGEN
 
 // The following code allows us to pick some symbols directly from kernel32.dll
 // (against which we cannot link when building for WinStore-ARM for instance.


### PR DESCRIPTION
This skips all the extra wrappers we have for Windows and Linux. These
are just redefinitions of system headers so we don't need to include
them in our documentation.