### PR TITLE
Make sure to cleanup pipes before waiting on connection from lldb

### DIFF
--- a/Sources/main.cpp
+++ b/Sources/main.cpp
@@ -167,14 +167,14 @@ static int SlaveMain() {
   }
 
   if (pid == 0) {
-    std::unique_ptr<Socket> client = server->accept();
-
     // When in slave mode, output is suppressed but for standard error.
     close(0);
     close(1);
 
     open("/dev/null", O_RDONLY);
     open("/dev/null", O_WRONLY);
+
+    std::unique_ptr<Socket> client = server->accept();
 
     SlaveSessionImpl impl;
     return RunDebugServer(client.get(), &impl);


### PR DESCRIPTION
This fixes a deadlock, where the platform-mode ds2
was waiting on the pipe closes, lldb was waiting on
platform-mode ds2, and slave-mode ds2 was waiting on lldb.