### PR TITLE
Get rid of `[[noreturn]]` on `onExitServer`.

### DIFF
--- a/Headers/DebugServer2/GDBRemote/DebugSessionImpl.h
+++ b/Headers/DebugServer2/GDBRemote/DebugSessionImpl.h
@@ -148,7 +148,7 @@ protected:
   ErrorCode onTerminate(Session &session, ProcessThreadId const &ptid,
                         StopInfo &stop) override;
   ErrorCode onDetach(Session &session, ProcessId pid, bool stopped) override;
-  [[noreturn]] ErrorCode onExitServer(Session &session) override;
+  ErrorCode onExitServer(Session &session) override;
 
 protected:
   ErrorCode onInsertBreakpoint(Session &session, BreakpointType type,

--- a/Sources/GDBRemote/DebugSessionImpl.cpp
+++ b/Sources/GDBRemote/DebugSessionImpl.cpp
@@ -1043,7 +1043,7 @@ ErrorCode DebugSessionImplBase::onTerminate(Session &session,
   return queryStopInfo(session, _process->currentThread(), stop);
 }
 
-[[noreturn]] ErrorCode DebugSessionImplBase::onExitServer(Session &session) {
+ErrorCode DebugSessionImplBase::onExitServer(Session &session) {
   ErrorCode error = kSuccess;
   ProcessId pid = kAnyProcessId;
   StopInfo stop;


### PR DESCRIPTION
Not all session delegates implement `onExitServer` and some might return
an error, using `noreturn` means not all overrides have the same
interface.