### PR TITLE
Mark language as generic in travis config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,9 @@
 ## PATENTS file in the same directory.
 ##
 
-sudo: required
 dist: trusty
+sudo: required
+language: generic
 branches:
   only:
     - master


### PR DESCRIPTION
Without this, travis defaults to ruby for some reason, and does some
useless work at the beginning to support ruby testing.