### PR TITLE
Adding write permissions before writing to a page

### DIFF
--- a/Sources/Target/Windows/Process.cpp
+++ b/Sources/Target/Windows/Process.cpp
@@ -398,10 +398,11 @@ Process::makeMemoryWritable(Address const &address, size_t length,
     MemoryRegionInfo region;
     CHK(getMemoryRegionInfoInternal(address, region));
 
-    if (region.protection == kProtectionRead || !region.protection) {
-      LPVOID allocError = ::VirtualAllocEx(
+    if (!region.protection || !(region.protection & kProtectionWrite)) {
+      LPVOID allocError = VirtualAllocEx(
           _handle, reinterpret_cast<LPVOID>(region.start.value()),
-          region.length, MEM_COMMIT, PAGE_READWRITE);
+          region.length, MEM_COMMIT, convertMemoryProtectionToWindows(
+                                         region.protection | kProtectionWrite));
 
       // The region could have been modified even if `VirtualAllocEx` failed.
       modifiedRegions.push_back(region);


### PR DESCRIPTION
The current version of LLDB is using a different set of permissions when creating pages in the target, which has triggered a bug in this code. This patch fixes this issue by adding a write permission whenever we want to write to a page, without changing the other existing permissions