### PR TITLE
Reduce the number of `Info` logs

### DIFF
--- a/Sources/GDBRemote/DebugSessionImpl.cpp
+++ b/Sources/GDBRemote/DebugSessionImpl.cpp
@@ -840,7 +840,7 @@ ErrorCode DebugSessionImplBase::onAttach(Session &session, ProcessId pid,
   if (mode != kAttachNow)
     return kErrorInvalidArgument;
 
-  DS2LOG(Info, "attaching to pid %" PRIu64, (uint64_t)pid);
+  DS2LOG(Debug, "attaching to pid %" PRIu64, (uint64_t)pid);
   _process = Target::Process::Attach(pid);
   if (_process == nullptr) {
     return kErrorProcessNotFound;
@@ -1134,21 +1134,22 @@ ErrorCode DebugSessionImplBase::onRemoveBreakpoint(Session &session,
 
 ErrorCode DebugSessionImplBase::spawnProcess(StringCollection const &args,
                                              EnvironmentBlock const &env) {
-  if (GetLogLevel() >= kLogLevelInfo) {
-    DS2LOG(Info, "spawning process '%s'", args[0].c_str());
-  } else {
-    DS2LOG(Debug, "spawning process with args:");
-    for (auto const &arg : args)
-      DS2LOG(Debug, "  %s", arg.c_str());
+  bool displayArgs = args.size() > 1;
+  auto it = args.begin();
+  DS2LOG(Debug, "spawning process '%s'%s", (it++)->c_str(),
+         displayArgs ? " with args:" : "");
+  while (it != args.end()) {
+    DS2LOG(Debug, "  %s", (it++)->c_str());
   }
 
   _spawner.setExecutable(args[0]);
   _spawner.setArguments(StringCollection(args.begin() + 1, args.end()));
 
   if (!env.empty()) {
-    DS2LOG(Debug, "and with environment:");
-    for (auto const &val : env)
+    DS2LOG(Debug, "%swith environment:", displayArgs ? "and " : "");
+    for (auto const &val : env) {
       DS2LOG(Debug, "  %s=%s", val.first.c_str(), val.second.c_str());
+    }
 
     _spawner.setEnvironment(env);
   }

--- a/Sources/main.cpp
+++ b/Sources/main.cpp
@@ -61,7 +61,7 @@ CreateSocket(std::string const &host, std::string const &port, bool reverse) {
       DS2LOG(Fatal, "cannot connect to [%s:%s]: %s", host.c_str(), port.c_str(),
              socket->error().c_str());
     } else {
-      DS2LOG(Info, "connected to [%s:%s]", socket->address().c_str(),
+      DS2LOG(Debug, "connected to [%s:%s]", socket->address().c_str(),
              socket->port().c_str());
     }
   } else {
@@ -74,7 +74,7 @@ CreateSocket(std::string const &host, std::string const &port, bool reverse) {
         fprintf(stderr, "Listening on port %s\n", socket->port().c_str());
       }
 
-      DS2LOG(Info, "listening on [%s:%s]", socket->address().c_str(),
+      DS2LOG(Debug, "listening on [%s:%s]", socket->address().c_str(),
              socket->port().c_str());
     }
   }


### PR DESCRIPTION
These are displayed every time we debug something and they clutter the
terminal without serving any purpose.