### PR TITLE
Build on Xcode 8 too on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,10 +79,10 @@ matrix:
       osx_image: xcode7
       env: TARGET="Darwin-X86_64" CLANG="1"
     - os: osx
-      osx_image: xcode7.3
+      osx_image: xcode8
       env: TARGET="Darwin-X86_64" CLANG="0"
     - os: osx
-      osx_image: xcode7.3
+      osx_image: xcode8
       env: TARGET="Darwin-X86_64" CLANG="1"
 
 # Use travis_retry during install to reduce the impact of network failures.


### PR DESCRIPTION
The goal for mac is to build on each major release (7.0, 8.0, etc) + the
latest release (which was 7.3 before, and is 8.0 now). When Xcode 8.1
comes out, we'll add a new build for that.