### PR TITLE
Replace WaitForDebugEvent with WaitForDebugEventEx

### DIFF
--- a/Headers/DebugServer2/Host/Windows/ExtraWrappers.h
+++ b/Headers/DebugServer2/Host/Windows/ExtraWrappers.h
@@ -20,6 +20,12 @@
 #define DS2_EXCEPTION_UNCAUGHT_USER 0xE06D7363
 #define DS2_EXCEPTION_UNCAUGHT_WINRT 0x40080201
 
+// Some APIs require a sufficiently new version of OS
+// but have a reasonable replacement for the older versions.
+#if !defined(_WIN32_WINNT_WIN10) && !defined(_WIN32_WINNT_WINTHRESHOLD)
+#define WaitForDebugEventEx WaitForDebugEvent
+#endif
+
 // Some APIs are not exposed when building for UAP.
 #if !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
 
@@ -343,7 +349,7 @@ WINBASEAPI BOOL WINAPI FlushInstructionCache(
   _In_ SIZE_T  dwSize
 );
 
-WINBASEAPI BOOL WINAPI WaitForDebugEvent(
+WINBASEAPI BOOL WINAPI WaitForDebugEventEx(
   _Out_  LPDEBUG_EVENT lpDebugEvent,
   _In_   DWORD dwMilliseconds
 );

--- a/Sources/Target/Windows/Process.cpp
+++ b/Sources/Target/Windows/Process.cpp
@@ -195,7 +195,7 @@ ErrorCode Process::wait() {
     _currentThread = nullptr;
 
     DEBUG_EVENT de;
-    BOOL result = ::WaitForDebugEvent(&de, INFINITE);
+    BOOL result = ::WaitForDebugEventEx(&de, INFINITE);
     if (!result)
       return Platform::TranslateError();
 


### PR DESCRIPTION
Use WaitForDebugEventEx instead of WaitForDebugEvent
to properly handle unicode strings sent by OutputDebugStringW.
Apply clang-format to the diff:
clang-format -i -style=llvm -lines=248:261 Sources/Target/Windows/Thread.cpp