### PR TITLE
Add name field in MemoryRegionInfo response

### DIFF
--- a/Headers/DebugServer2/Types.h
+++ b/Headers/DebugServer2/Types.h
@@ -301,6 +301,7 @@ struct MemoryRegionInfo {
   Address start;
   uint64_t length;
   uint32_t protection;
+  std::string name;
 #if defined(OS_LINUX)
   std::string backingFile;
   uint64_t backingFileOffset;
@@ -309,17 +310,19 @@ struct MemoryRegionInfo {
 
   MemoryRegionInfo() { clear(); }
   MemoryRegionInfo(Address const &start_, uint64_t length_,
-                   uint64_t protection_) {
+                   uint64_t protection_, std::string name_) {
     clear();
     start = start_;
     length = length_;
     protection = protection_;
+    name = name_;
   }
 
   inline void clear() {
     start.clear();
     length = 0;
     protection = 0;
+    name.clear();
 #if defined(OS_LINUX)
     backingFile.clear();
     backingFileOffset = 0;

--- a/Headers/DebugServer2/Utils/String.h
+++ b/Headers/DebugServer2/Utils/String.h
@@ -17,6 +17,9 @@
 #include <sstream>
 #include <string>
 
+#define STR_HELPER(S) #S
+#define STR(S) STR_HELPER(S)
+
 namespace ds2 {
 namespace Utils {
 

--- a/Sources/GDBRemote/Structures.cpp
+++ b/Sources/GDBRemote/Structures.cpp
@@ -785,6 +785,9 @@ std::string MemoryRegionInfo::encode() const {
       ss << 'x';
     ss << ';';
   }
+  if (!name.empty()) {
+    ss << "name:" << ToHex(name) << ';';
+  }
 
   return ss.str();
 }


### PR DESCRIPTION
When LLDB calls GetMemoryRegionInfo on a process that goes through GDBRemoteCommunicationClient, it communicates with ds2 to grab the MemoryRegionInfo from the process. However, in LLDB 4.0, they added a `name` field in the response packet. That is, in addition to `start`, `size`, and `permissions`, `name` is something you can expect to see. I have updated ds2 to reflect this.