### PR TITLE
Update the prepare-android-toolchain script to use ndk r14b

### DIFF
--- a/Support/Scripts/prepare-android-toolchain.sh
+++ b/Support/Scripts/prepare-android-toolchain.sh
@@ -11,7 +11,7 @@
 
 source "$(dirname "$0")/common.sh"
 
-ndk_release="r13b"
+ndk_release="r14b"
 install_dir="/tmp/aosp-toolchain"
 
 case "$(uname)" in


### PR DESCRIPTION
This is a relatively straightforward change. It just changes which NDK is downloaded. That is, we go from `android-ndk-r13b-linux-x86_64.zip` to `android-ndk-r14b-linux-x86_64.zip`.