### PR TITLE
Fix ProcFS population of ProcessInfo on Linux

### DIFF
--- a/Sources/Target/Linux/Process.cpp
+++ b/Sources/Target/Linux/Process.cpp
@@ -302,7 +302,7 @@ ErrorCode Process::updateInfo() {
   //
   // Some info like parent pid, OS vendor, etc is obtained via /proc.
   //
-  ProcFS::ReadProcessInfo(_info.pid, _info);
+  ProcFS::ReadProcessInfo(_pid, _info);
 
   //
   // Call super::updateInfo, in turn it will call updateAuxiliaryVector.


### PR DESCRIPTION
ProcFS::ReadProcessInfo was not properly populating the ProcessInfo struct (was filling it in with ds2's info since `_info.pid` == 0 initially) and we used ELFProcess::updateInfo as a fallback to update it correctly. This should fix things so that ProcFS::ReadProcessInfo doesn't incorrectly populate the ProcessInfo struct and ELFProcess::updateInfo can instead return early.