### PR TITLE
Force re-installation of android toolchain if directory already exists

### DIFF
--- a/Support/Scripts/prepare-android-toolchain.sh
+++ b/Support/Scripts/prepare-android-toolchain.sh
@@ -59,7 +59,8 @@ for arg in "$@"; do
   "${ndk_path}/build/tools/make_standalone_toolchain.py" \
       --arch "${target_arch}" \
       --api "${api_level}"    \
-      --install-dir "${toolchain_install_dir}"
+      --install-dir "${toolchain_install_dir}" \
+      --force
 
   rm -f "${install_dir}/${target_arch}"
   ln -s "${toolchain_install_dir}" "${install_dir}/${target_arch}"


### PR DESCRIPTION
Prevents the script from failing if a previous installation exists. Should reduce some Travis flakiness.