### PR TITLE
Check return value of enable and disable functions

### DIFF
--- a/Headers/DebugServer2/Core/BreakpointManager.h
+++ b/Headers/DebugServer2/Core/BreakpointManager.h
@@ -76,7 +76,8 @@ public:
   virtual bool has(Address const &address) const;
 
 public:
-  virtual void enumerate(std::function<void(Site const &)> const &cb) const;
+  virtual ErrorCode
+  enumerate(std::function<ErrorCode(Site const &)> const &cb) const;
 
 protected:
   virtual ErrorCode isValid(Address const &address, size_t size,
@@ -94,8 +95,8 @@ public:
   virtual int hit(Target::Thread *thread, Site &site) = 0;
 
 public:
-  virtual void enable(Target::Thread *thread = nullptr);
-  virtual void disable(Target::Thread *thread = nullptr);
+  virtual ErrorCode enable(Target::Thread *thread = nullptr);
+  virtual ErrorCode disable(Target::Thread *thread = nullptr);
 
 protected:
   virtual ErrorCode enableLocation(Site const &site,

--- a/Headers/DebugServer2/Core/HardwareBreakpointManager.h
+++ b/Headers/DebugServer2/Core/HardwareBreakpointManager.h
@@ -45,8 +45,8 @@ public:
   virtual size_t maxWatchpoints();
 
 public:
-  void enable(Target::Thread *thread = nullptr) override;
-  void disable(Target::Thread *thread = nullptr) override;
+  ErrorCode enable(Target::Thread *thread = nullptr) override;
+  ErrorCode disable(Target::Thread *thread = nullptr) override;
 
 protected:
   ErrorCode isValid(Address const &address, size_t size,

--- a/Headers/DebugServer2/Core/SoftwareBreakpointManager.h
+++ b/Headers/DebugServer2/Core/SoftwareBreakpointManager.h
@@ -38,8 +38,8 @@ protected:
                                     Target::Thread *thread = nullptr) override;
 
 public:
-  void enable(Target::Thread *thread = nullptr) override;
-  void disable(Target::Thread *thread = nullptr) override;
+  ErrorCode enable(Target::Thread *thread = nullptr) override;
+  ErrorCode disable(Target::Thread *thread = nullptr) override;
 
 protected:
   ErrorCode isValid(Address const &address, size_t size,
@@ -47,8 +47,8 @@ protected:
 
 #if defined(ARCH_ARM) || defined(ARCH_ARM64)
 public:
-  virtual void
-  enumerate(std::function<void(Site const &)> const &cb) const override;
+  virtual ErrorCode
+  enumerate(std::function<ErrorCode(Site const &)> const &cb) const override;
 
 public:
   virtual ErrorCode add(Address const &address, Type type, size_t size,

--- a/Sources/Core/ARM/SoftwareBreakpointManager.cpp
+++ b/Sources/Core/ARM/SoftwareBreakpointManager.cpp
@@ -69,18 +69,18 @@ bool SoftwareBreakpointManager::has(Address const &address) const {
   return super::has(address);
 }
 
-void SoftwareBreakpointManager::enumerate(
-    std::function<void(Site const &)> const &cb) const {
+ErrorCode SoftwareBreakpointManager::enumerate(
+    std::function<ErrorCode(Site const &)> const &cb) const {
   //
   // Remove the thumb bit.
   //
-  super::enumerate([&](Site const &site) {
+  return super::enumerate([&](Site const &site) {
     if (site.address & 1) {
       Site copy(site);
       copy.address = copy.address.value() & ~1;
-      cb(copy);
+      return cb(copy);
     } else {
-      cb(site);
+      return cb(site);
     }
   });
 }

--- a/Sources/Core/HardwareBreakpointManager.cpp
+++ b/Sources/Core/HardwareBreakpointManager.cpp
@@ -122,18 +122,20 @@ void HardwareBreakpointManager::enumerateThreads(
   }
 }
 
-void HardwareBreakpointManager::enable(Target::Thread *thread) {
-  super::enable(thread);
+ErrorCode HardwareBreakpointManager::enable(Target::Thread *thread) {
+  ErrorCode error = super::enable(thread);
 
   enumerateThreads(thread,
                    [this](Target::Thread *t) { _enabled.insert(t->tid()); });
+  return error;
 }
 
-void HardwareBreakpointManager::disable(Target::Thread *thread) {
-  super::disable(thread);
+ErrorCode HardwareBreakpointManager::disable(Target::Thread *thread) {
+  ErrorCode error = super::disable(thread);
 
   enumerateThreads(thread,
                    [this](Target::Thread *t) { _enabled.erase(t->tid()); });
+  return error;
 }
 
 bool HardwareBreakpointManager::enabled(Target::Thread *thread) const {

--- a/Sources/Core/SoftwareBreakpointManager.cpp
+++ b/Sources/Core/SoftwareBreakpointManager.cpp
@@ -94,16 +94,18 @@ ErrorCode SoftwareBreakpointManager::disableLocation(Site const &site,
   return kSuccess;
 }
 
-void SoftwareBreakpointManager::enable(Target::Thread *thread) {
-  super::enable(thread);
+ErrorCode SoftwareBreakpointManager::enable(Target::Thread *thread) {
+  ErrorCode error = super::enable(thread);
 
   _enabled = true;
+  return error;
 }
 
-void SoftwareBreakpointManager::disable(Target::Thread *thread) {
-  super::disable(thread);
+ErrorCode SoftwareBreakpointManager::disable(Target::Thread *thread) {
+  ErrorCode error = super::disable(thread);
 
   _enabled = false;
+  return error;
 }
 
 bool SoftwareBreakpointManager::enabled(Target::Thread *thread) const {

--- a/Sources/Target/Common/ProcessBase.cpp
+++ b/Sources/Target/Common/ProcessBase.cpp
@@ -290,7 +290,7 @@ ErrorCode ProcessBase::beforeResume() {
   //
   BreakpointManager *bpm = softwareBreakpointManager();
   if (bpm != nullptr) {
-    bpm->enable();
+    CHK(bpm->enable());
   }
 
   enumerateThreads([&](Thread *thread) { thread->beforeResume(); });
@@ -312,12 +312,12 @@ ErrorCode ProcessBase::afterResume() {
         DS2LOG(Debug, "hit breakpoint for tid %" PRI_PID, it.second->tid());
       }
     }
-    swBpm->disable();
+    CHK(swBpm->disable());
   }
 
   BreakpointManager *hwBpm = hardwareBreakpointManager();
   if (hwBpm != nullptr) {
-    hwBpm->disable();
+    CHK(hwBpm->disable());
   }
 
   return kSuccess;

--- a/Sources/Target/Common/ThreadBase.cpp
+++ b/Sources/Target/Common/ThreadBase.cpp
@@ -34,7 +34,7 @@ ErrorCode ThreadBase::modifyRegisters(
 ErrorCode ThreadBase::beforeResume() {
   BreakpointManager *bpm = _process->hardwareBreakpointManager();
   if (bpm != nullptr) {
-    bpm->enable((Target::Thread *)this);
+    CHK(bpm->enable((Target::Thread *)this));
   }
 
   return kSuccess;


### PR DESCRIPTION
The return values of enable/disableLocation were ignored when
called via an enumeration. Propogate these errors to lldb instead.