### PR TITLE
Get rid of a useless ptid to pid conversion

### DIFF
--- a/Sources/Host/FreeBSD/PTrace.cpp
+++ b/Sources/Host/FreeBSD/PTrace.cpp
@@ -74,10 +74,7 @@ ErrorCode PTrace::readMemory(ProcessThreadId const &ptid,
                              Address const &address, void *buffer,
                              size_t length, size_t *count) {
   pid_t pid;
-
-  ErrorCode error = ptidToPid(ptid, pid);
-  if (error != kSuccess)
-    return error;
+  CHK(ptidToPid(ptid, pid));
 
   uintptr_t base = address.value();
   struct ptrace_io_desc desc;
@@ -106,10 +103,7 @@ ErrorCode PTrace::writeMemory(ProcessThreadId const &ptid,
                               Address const &address, void const *buffer,
                               size_t length, size_t *count) {
   pid_t pid;
-
-  ErrorCode error = ptidToPid(ptid, pid);
-  if (error != kSuccess)
-    return error;
+  CHK(ptidToPid(ptid, pid));
 
   uintptr_t base = address;
   struct ptrace_io_desc desc;
@@ -137,10 +131,7 @@ ErrorCode PTrace::writeMemory(ProcessThreadId const &ptid,
 ErrorCode PTrace::getLwpInfo(ProcessThreadId const &ptid,
                              struct ptrace_lwpinfo *lwpinfo) {
   pid_t pid;
-
-  ErrorCode error = ptidToPid(ptid, pid);
-  if (error != kSuccess)
-    return error;
+  CHK(ptidToPid(ptid, pid));
 
   if (wrapPtrace(PT_LWPINFO, pid, lwpinfo, sizeof(struct ptrace_lwpinfo)) < 0)
     return Platform::TranslateError();
@@ -151,10 +142,7 @@ ErrorCode PTrace::getLwpInfo(ProcessThreadId const &ptid,
 ErrorCode PTrace::getSigInfo(ProcessThreadId const &ptid, siginfo_t &si) {
   struct ptrace_lwpinfo lwpinfo;
   pid_t pid;
-
-  ErrorCode error = ptidToPid(ptid, pid);
-  if (error != kSuccess)
-    return error;
+  CHK(ptidToPid(ptid, pid));
 
   if (wrapPtrace(PT_LWPINFO, pid, &lwpinfo, sizeof lwpinfo) < 0)
     return Platform::TranslateError();

--- a/Sources/Host/FreeBSD/X86_64/PTraceX86_64.cpp
+++ b/Sources/Host/FreeBSD/X86_64/PTraceX86_64.cpp
@@ -172,10 +172,7 @@ ErrorCode PTrace::readCPUState(ProcessThreadId const &ptid,
                                ProcessInfo const &pinfo,
                                Architecture::CPUState &state) {
   pid_t pid;
-
-  ErrorCode error = ptidToPid(ptid, pid);
-  if (error != kSuccess)
-    return error;
+  CHK(ptidToPid(ptid, pid));
 
   //
   // Read GPRs
@@ -211,10 +208,7 @@ ErrorCode PTrace::writeCPUState(ProcessThreadId const &ptid,
                                 ProcessInfo const &pinfo,
                                 Architecture::CPUState const &state) {
   pid_t pid;
-
-  ErrorCode error = ptidToPid(ptid, pid);
-  if (error != kSuccess)
-    return error;
+  CHK(ptidToPid(ptid, pid));
 
   if (pinfo.pointerSize == sizeof(uint32_t) && !state.is32)
     return kErrorInvalidArgument;

--- a/Sources/Host/Linux/ARM/PTraceARM.cpp
+++ b/Sources/Host/Linux/ARM/PTraceARM.cpp
@@ -31,10 +31,7 @@ namespace Linux {
 ErrorCode PTrace::readCPUState(ProcessThreadId const &ptid, ProcessInfo const &,
                                Architecture::CPUState &state) {
   pid_t pid;
-
-  ErrorCode error = ptidToPid(ptid, pid);
-  if (error != kSuccess)
-    return error;
+  CHK(ptidToPid(ptid, pid));
 
   //
   // Read GPRs
@@ -59,10 +56,10 @@ ErrorCode PTrace::readCPUState(ProcessThreadId const &ptid, ProcessInfo const &,
 
 uint32_t PTrace::getStoppointData(ProcessThreadId const &ptid) {
   pid_t pid;
-
   ErrorCode error = ptidToPid(ptid, pid);
-  if (error != kSuccess)
+  if (error != kSuccess) {
     return 0;
+  }
 
   //
   // Retrieve the information about Hardware Breakpoint, if supported.
@@ -97,10 +94,7 @@ ErrorCode PTrace::writeCPUState(ProcessThreadId const &ptid,
                                 ProcessInfo const &,
                                 Architecture::CPUState const &state) {
   pid_t pid;
-
-  ErrorCode error = ptidToPid(ptid, pid);
-  if (error != kSuccess)
-    return error;
+  CHK(ptidToPid(ptid, pid));
 
   //
   // Read GPRs
@@ -128,10 +122,7 @@ ErrorCode PTrace::writeCPUState(ProcessThreadId const &ptid,
 ErrorCode PTrace::writeStoppoint(ProcessThreadId const &ptid, size_t idx,
                                  uint32_t *val) {
   pid_t pid;
-
-  ErrorCode error = ptidToPid(ptid, pid);
-  if (error != kSuccess)
-    return error;
+  CHK(ptidToPid(ptid, pid));
 
   if (wrapPtrace(PTRACE_SETHBPREGS, pid, idx, val) < 0)
     return Platform::TranslateError();

--- a/Sources/Host/Linux/ARM64/PTraceARM64.cpp
+++ b/Sources/Host/Linux/ARM64/PTraceARM64.cpp
@@ -24,13 +24,6 @@ namespace Host {
 namespace Linux {
 
 int PTrace::getMaxStoppoints(ProcessThreadId const &ptid, int regSet) {
-  pid_t pid;
-
-  ErrorCode error = ptidToPid(ptid, pid);
-
-  if (error != kSuccess)
-    return 0;
-
   // Retrieve the information about Hardware Breakpoint, if supported.
   // user_hwdebug_state.dbg_info is formatted as follows:
   //
@@ -41,7 +34,7 @@ int PTrace::getMaxStoppoints(ProcessThreadId const &ptid, int regSet) {
   //
   // DEBUG_ARCH should be 0x06 for aarch64-armv8a.
   struct user_hwdebug_state drs;
-  if (readRegisterSet(pid, regSet, &drs, sizeof(drs)) != kSuccess ||
+  if (readRegisterSet(ptid, regSet, &drs, sizeof(drs)) != kSuccess ||
       ((drs.dbg_info >> 8) & 0xff) != 0x06) {
     return 0;
   }

--- a/Sources/Host/Linux/PTrace.cpp
+++ b/Sources/Host/Linux/PTrace.cpp
@@ -32,10 +32,7 @@ namespace Linux {
 
 ErrorCode PTrace::wait(ProcessThreadId const &ptid, int *status) {
   pid_t pid;
-
-  ErrorCode error = ptidToPid(ptid, pid);
-  if (error != kSuccess)
-    return error;
+  CHK(ptidToPid(ptid, pid));
 
   int stat;
   pid_t ret;
@@ -105,10 +102,7 @@ ErrorCode PTrace::readBytes(ProcessThreadId const &ptid, Address const &address,
                             void *buffer, size_t length, size_t *count,
                             bool nullTerm) {
   pid_t pid;
-
-  ErrorCode error = ptidToPid(ptid, pid);
-  if (error != kSuccess)
-    return error;
+  CHK(ptidToPid(ptid, pid));
 
   bool foundNull = false;
   size_t nread = 0;
@@ -187,10 +181,7 @@ ErrorCode PTrace::writeMemory(ProcessThreadId const &ptid,
                               Address const &address, void const *buffer,
                               size_t length, size_t *count) {
   pid_t pid;
-
-  ErrorCode error = ptidToPid(ptid, pid);
-  if (error != kSuccess)
-    return error;
+  CHK(ptidToPid(ptid, pid));
 
   size_t nwritten = 0;
   uintptr_t base = address;
@@ -286,10 +277,7 @@ ErrorCode PTrace::resume(ProcessThreadId const &ptid, ProcessInfo const &pinfo,
 
 ErrorCode PTrace::getSigInfo(ProcessThreadId const &ptid, siginfo_t &si) {
   pid_t pid;
-
-  ErrorCode error = ptidToPid(ptid, pid);
-  if (error != kSuccess)
-    return error;
+  CHK(ptidToPid(ptid, pid));
 
   if (wrapPtrace(PTRACE_GETSIGINFO, pid, nullptr, &si) < 0)
     return Platform::TranslateError();

--- a/Sources/Host/Linux/X86/PTraceX86.cpp
+++ b/Sources/Host/Linux/X86/PTraceX86.cpp
@@ -108,10 +108,7 @@ state32_to_user(struct xfpregs_struct &xfpregs,
 ErrorCode PTrace::readCPUState(ProcessThreadId const &ptid, ProcessInfo const &,
                                Architecture::CPUState &state) {
   pid_t pid;
-
-  ErrorCode error = ptidToPid(ptid, pid);
-  if (error != kSuccess)
-    return error;
+  CHK(ptidToPid(ptid, pid));
 
   //
   // Read GPRs
@@ -162,10 +159,7 @@ ErrorCode PTrace::writeCPUState(ProcessThreadId const &ptid,
                                 ProcessInfo const &,
                                 Architecture::CPUState const &state) {
   pid_t pid;
-
-  ErrorCode error = ptidToPid(ptid, pid);
-  if (error != kSuccess)
-    return error;
+  CHK(ptidToPid(ptid, pid));
 
   //
   // Write GPRs

--- a/Sources/Host/Linux/X86_64/PTraceX86_64.cpp
+++ b/Sources/Host/Linux/X86_64/PTraceX86_64.cpp
@@ -219,10 +219,7 @@ ErrorCode PTrace::readCPUState(ProcessThreadId const &ptid,
                                ProcessInfo const &pinfo,
                                Architecture::CPUState &state) {
   pid_t pid;
-
-  ErrorCode error = ptidToPid(ptid, pid);
-  if (error != kSuccess)
-    return error;
+  CHK(ptidToPid(ptid, pid));
 
   //
   // Read GPRs
@@ -287,10 +284,7 @@ ErrorCode PTrace::writeCPUState(ProcessThreadId const &ptid,
                                 ProcessInfo const &pinfo,
                                 Architecture::CPUState const &state) {
   pid_t pid;
-
-  ErrorCode error = ptidToPid(ptid, pid);
-  if (error != kSuccess)
-    return error;
+  CHK(ptidToPid(ptid, pid));
 
   if (pinfo.pointerSize == sizeof(uint32_t) && !state.is32)
     return kErrorInvalidArgument;

--- a/Sources/Host/POSIX/PTrace.cpp
+++ b/Sources/Host/POSIX/PTrace.cpp
@@ -96,10 +96,7 @@ ErrorCode PTrace::suspend(ProcessThreadId const &ptid) {
 ErrorCode PTrace::doStepResume(bool stepping, ProcessThreadId const &ptid,
                                int signal, Address const &address) {
   pid_t pid;
-
-  ErrorCode error = ptidToPid(ptid, pid);
-  if (error != kSuccess)
-    return error;
+  CHK(ptidToPid(ptid, pid));
 
 #if defined(OS_LINUX)
   // Handling of continuation address is performed in Linux::PTrace.


### PR DESCRIPTION
This code wasn't doing anything because the pid was implicitly getting
converted back to a ptid anyway.