### PR TITLE
Pull correct llvm packages from llvm's apt repositories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ branches:
   only:
     - master
 
+env:
+  global:
+    - LINUX_DISTRO="trusty"
+
 matrix:
   fast_finish: true
   include:

--- a/Support/Testing/Travis/before-install.py
+++ b/Support/Testing/Travis/before-install.py
@@ -28,10 +28,10 @@ elif host == 'Linux':
 
     def add_llvm_repo():
         add_toolchain_test_repo()
-        (dist,version,name) = platform.linux_distribution()
+        dist = os.getenv("LINUX_DISTRO")
         keys.append('http://llvm.org/apt/llvm-snapshot.gpg.key')
-        llvm_url = 'http://llvm.org/apt/' + name + '/'
-        repo_name = 'llvm-toolchain-' + name + '-4.0'
+        llvm_url = 'http://llvm.org/apt/' + dist + '/'
+        repo_name = 'llvm-toolchain-' + dist + '-4.0'
         repositories.append('deb ' + llvm_url + ' ' + repo_name + ' main')
 
     if target in [ 'Style', 'Registers' ]:

--- a/Support/Testing/Travis/script.sh
+++ b/Support/Testing/Travis/script.sh
@@ -22,7 +22,7 @@ if same_dir "$PWD" "$top"; then
 fi
 
 # Get a recent cmake from cmake.org; packages for Ubuntu are too old.
-cmake_version="3.6"
+cmake_version="3.7"
 cmake_package="cmake-${cmake_version}.0-Linux-x86_64"
 if [ "$(linux_distribution)" == "ubuntu" ] && [ ! -d "/tmp/$cmake_package/bin" ]; then
   cd /tmp


### PR DESCRIPTION
For some reason, `platform.linux_distribution()` is failing on travis now, causing our build to fail. I've hardcoded 'trusty' for the time being as it's [becoming the default linux test environment](https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming). There doesn't seem to a be a super convenient way to get the distribution name, so let's put it as an environment variable.