### PR TITLE
Install ninja-build instead of ninja when on trusty without using `platform.linux_distribution()`

### DIFF
--- a/Support/Testing/Travis/install.py
+++ b/Support/Testing/Travis/install.py
@@ -39,7 +39,7 @@ if host == 'Darwin':
     if os.getenv('CLANG') != '1':
         dist_packages.append('gcc')
 elif host == 'Linux':
-    if "Ubuntu" in platform.linux_distribution():
+    if os.getenv("LINUX_DISTRO") == "trusty":
         dist_packages.append('ninja-build')
     else:
         dist_packages.append('ninja')


### PR DESCRIPTION
platform.linux_distribution() is unreliable on travis. We should rely on environment variables set by our .travis.yml, as unclean as that might sound. This should fix our build.