### PR TITLE
Remove temporary zips and tarballs during setup for more space

### DIFF
--- a/Support/Scripts/install-android-emulator.sh
+++ b/Support/Scripts/install-android-emulator.sh
@@ -51,6 +51,7 @@ if [ ! -f "$android_script" ]; then
     "tgz") tar -C /tmp -xvf "/tmp/${android_sdk_package}";;
     *) die "Unknown archive extension '${package_extension}'."
   esac
+  rm -f "/tmp/${android_sdk_package}"
 fi
 
 for package in "${package_list[@]}"; do

--- a/Support/Scripts/prepare-android-toolchain.sh
+++ b/Support/Scripts/prepare-android-toolchain.sh
@@ -41,6 +41,7 @@ if [ -z "${ndk_path-}" ]; then
 
   wget "https://dl.google.com/android/repository/${ndk_package_archive}"
   unzip -q "${ndk_package_archive}"
+  rm -f "${ndk_package_archive}"
 
   ndk_path="$(realpath "$ndk_package_base")"
 fi

--- a/Support/Scripts/run-gdb-tests.sh
+++ b/Support/Scripts/run-gdb-tests.sh
@@ -27,6 +27,7 @@ gdb_src_path="$build_dir/$gdb_basename"
 
 wget "$gdb_ftp_path/$gdb_basename.tar.gz"
 tar -zxf "$gdb_basename.tar.gz"
+rm -f "${gdb_basename}.tar.gz"
 
 testingPath="$top/Support/Testing"
 for p in $testingPath/Patches/gdb/*.patch; do

--- a/Support/Testing/Travis/script.sh
+++ b/Support/Testing/Travis/script.sh
@@ -32,6 +32,7 @@ if [ "$(linux_distribution)" == "ubuntu" ] && [ ! -d "/tmp/$cmake_package/bin" ]
   fi
 
   tar -xf "${cmake_package}.tar.gz"
+  rm -f "${cmake_package}.tar.gz"
 
   cd "$OLDPWD"
 fi


### PR DESCRIPTION
Currently one of the targets fails pretty consistently with the error `NAND: could not write file /home/travis/.android/avd/test.avd/userdata-qemu.img, No space left on device`. In this PR, I aim to try and reduce the amount of space as much as possible. Currently all I've done is delete the sdk's zip/tarball. If this isn't enough, I can stack more diffs deleting more things.