### PR TITLE
Inspect what takes up so much space on Travis

### DIFF
--- a/Support/Scripts/install-android-emulator.sh
+++ b/Support/Scripts/install-android-emulator.sh
@@ -57,7 +57,16 @@ for package in "${package_list[@]}"; do
   echo "y" | "$android_script" update sdk -u -a --filter "$package"
 done
 
-du -sh * /tmp/*
+echo "=========== install-android-emulator.sh =========== "
+echo "Installing android emulator"
+echo "du -sh $(pwd)"
+du -sh *
+echo "du -sh home"
+du -sh ~/*
+echo "du -sh /tmp"
+du -sh /tmp/*
+echo "how much space are we given anyway?"
 df -h
+echo "=========== install-android-emulator.sh =========== "
 
 echo "no" | "$android_script" create avd --force -n test -t "android-${api_level}" --abi "${emulator_image_arch}"

--- a/Support/Scripts/install-android-emulator.sh
+++ b/Support/Scripts/install-android-emulator.sh
@@ -57,4 +57,7 @@ for package in "${package_list[@]}"; do
   echo "y" | "$android_script" update sdk -u -a --filter "$package"
 done
 
+du -sh * /tmp/*
+df -h
+
 echo "no" | "$android_script" create avd --force -n test -t "android-${api_level}" --abi "${emulator_image_arch}"

--- a/Support/Testing/Travis/script.sh
+++ b/Support/Testing/Travis/script.sh
@@ -14,6 +14,27 @@ source "$top/Support/Scripts/common.sh"
 
 cformat="clang-format-4.0"
 
+if [ -e "~/perl5" ]; then
+    echo "Removing perl5"
+    rm -rf ~/perl5
+fi
+if [ -e "~/otp" ]; then
+    echo "Removing otp"
+    rm -rf ~/otp
+fi
+
+echo "=== script.sh ==="
+echo "yet another diskutility check"
+echo "du -sh $(pwd)"
+du -sh *
+echo "du -sh home"
+du -sh ~/*
+echo "du -sh /tmp"
+du -sh /tmp/*
+echo "df -h"
+df -h
+echo "=== script.sh ==="
+
 # If we're at the root of the repository, create a build directory and go
 # there; otherwise, assume that we're already in the build directory the user
 # wants to use.

--- a/Support/Testing/Travis/script.sh
+++ b/Support/Testing/Travis/script.sh
@@ -14,23 +14,19 @@ source "$top/Support/Scripts/common.sh"
 
 cformat="clang-format-4.0"
 
-if [ -e "~/perl5" ]; then
-    echo "Removing perl5"
-    rm -rf ~/perl5
-fi
-if [ -e "~/otp" ]; then
-    echo "Removing otp"
-    rm -rf ~/otp
-fi
+echo "Removing perl5"
+sudo rm -rf ~/perl5
+echo "Removing otp"
+sudo rm -rf ~/otp
 
 echo "=== script.sh ==="
 echo "yet another diskutility check"
 echo "du -sh $(pwd)"
 du -sh *
 echo "du -sh home"
-du -sh ~/*
+du -sh ~/.[!.]* ~/*
 echo "du -sh /tmp"
-du -sh /tmp/*
+du -sh /tmp/.[!.]* /tmp/*
 echo "df -h"
 df -h
 echo "=== script.sh ==="


### PR DESCRIPTION
This is stupid. For some reason, Travis runs out of space even if we remove a lot of the temporary files we download (*.zip and *.tar.gz files). See #500 for more context. What's taking up so much space, and why? Let's find out.