### PR TITLE
Remove perl5 and otp installs on travis

### DIFF
--- a/Support/Testing/Travis/script.sh
+++ b/Support/Testing/Travis/script.sh
@@ -14,6 +14,8 @@ source "$top/Support/Scripts/common.sh"
 
 cformat="clang-format-4.0"
 
+"$top/Support/Testing/Travis/travis-hacks.sh"
+
 # If we're at the root of the repository, create a build directory and go
 # there; otherwise, assume that we're already in the build directory the user
 # wants to use.

--- a/Support/Testing/Travis/travis-hacks.sh
+++ b/Support/Testing/Travis/travis-hacks.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+##
+## Copyright (c) 2014-present, Facebook, Inc.
+## All right reserved.
+##
+## This source code is licensed under the University of Illinois/NCSA Open
+## Source License found in the LICENSE file in the root directory of this
+## source tree. An additional grant of patent rights can be found in the
+## PATENTS file in the same directory.
+
+set -eu
+
+# We're running out of disk space on Travis. This is a dirty hack. We shouldn't
+# have to do this. In the home directory, perl5 takes up roughly 1.1GB of space
+# and otp takes up roughly 3.0GB. They are protected, but we should be able to
+# forcibly remove them with sudo.
+sudo rm -rf ~/perl5
+sudo rm -rf ~/otp


### PR DESCRIPTION
This is shitty hack. I feel bad about doing this, but I think it should fix our things in the short term while we come up with a better solution for the long term. I'm thinking we can probably play around with Travis settings until we find a sweet spot, but that will take more time to read the documentation and engage the Travis community. 