### PR TITLE
Enable HardwareWatchpointManager for Windows

### DIFF
--- a/Sources/Target/Common/ProcessBase.cpp
+++ b/Sources/Target/Common/ProcessBase.cpp
@@ -333,11 +333,6 @@ SoftwareBreakpointManager *ProcessBase::softwareBreakpointManager() const {
 }
 
 HardwareBreakpointManager *ProcessBase::hardwareBreakpointManager() const {
-#if defined(OS_WIN32)
-  // Not implemented yet.
-  return nullptr;
-#endif
-
   if (!_hardwareBreakpointManager) {
     _hardwareBreakpointManager = ds2::make_unique<HardwareBreakpointManager>(
         const_cast<ProcessBase *>(this));


### PR DESCRIPTION
I tested this locally. We now can set watchpoints on Windows Desktop targets (both x86 and x86_64), so it's ok to remove this ifdef guard. This should be the last step.