### PR TITLE
Ignore .swp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 build-*/
 html/
+*.swp


### PR DESCRIPTION
I often have files open in vim when I am looking at the status of the branch I'm on or staging files to commit. Seeing the .swp files there when i run `git status` just adds clutter. Let's ignore them, as they serve no benefit to actually have.