### PR TITLE
Fix typo in BreakpointManager comment

### DIFF
--- a/Sources/Core/BreakpointManager.cpp
+++ b/Sources/Core/BreakpointManager.cpp
@@ -67,7 +67,7 @@ ErrorCode BreakpointManager::remove(Address const &address) {
   if (!(it->second.type & kTypePermanent))
     goto do_remove;
 
-  // If we have a premanent breakpoint, refs should be non-null. If refs is
+  // If we have a permanent breakpoint, refs should be non-null. If refs is
   // still non-null after the decrement, do not remove the breakpoint and
   // return.
   DS2ASSERT(it->second.refs > 0);


### PR DESCRIPTION
Typo in a comment