### PR TITLE
Add support for watchpoints on Windows Desktop x86 and x86_64

### DIFF
--- a/Headers/DebugServer2/Core/BreakpointManager.h
+++ b/Headers/DebugServer2/Core/BreakpointManager.h
@@ -103,5 +103,8 @@ protected:
   virtual ErrorCode disableLocation(Site const &site,
                                     Target::Thread *thread = nullptr) = 0;
   virtual bool enabled(Target::Thread *thread = nullptr) const = 0;
+
+public:
+  virtual bool fillStopInfo(Target::Thread *thread, StopInfo &stopInfo) = 0;
 };
 } // namespace ds2

--- a/Headers/DebugServer2/Core/HardwareBreakpointManager.h
+++ b/Headers/DebugServer2/Core/HardwareBreakpointManager.h
@@ -76,5 +76,9 @@ protected:
   virtual ErrorCode enableDebugCtrlReg(uint64_t &ctrlReg, int idx, Mode mode,
                                        int size);
 #endif
+
+public:
+  virtual bool fillStopInfo(Target::Thread *thread,
+                            StopInfo &stopInfo) override;
 };
 } // namespace ds2

--- a/Headers/DebugServer2/Core/SoftwareBreakpointManager.h
+++ b/Headers/DebugServer2/Core/SoftwareBreakpointManager.h
@@ -60,5 +60,9 @@ public:
 #endif
 
   virtual bool enabled(Target::Thread *thread = nullptr) const override;
+
+public:
+  virtual bool fillStopInfo(Target::Thread *thread,
+                            StopInfo &stopInfo) override;
 };
 } // namespace ds2

--- a/Headers/DebugServer2/Target/Linux/Thread.h
+++ b/Headers/DebugServer2/Target/Linux/Thread.h
@@ -24,9 +24,6 @@ protected:
   Thread(Process *process, ThreadId tid);
 
 protected:
-  void fillWatchpointData();
-
-protected:
   ErrorCode updateStopInfo(int waitStatus) override;
   void updateState() override;
 };

--- a/Sources/Core/HardwareBreakpointManager.cpp
+++ b/Sources/Core/HardwareBreakpointManager.cpp
@@ -147,4 +147,33 @@ bool HardwareBreakpointManager::enabled(Target::Thread *thread) const {
 
   return isEnabled;
 }
+
+bool HardwareBreakpointManager::fillStopInfo(Target::Thread *thread,
+                                             StopInfo &stopInfo) {
+  BreakpointManager::Site site;
+  int bpIdx = hit(thread, site);
+  if (bpIdx < 0) {
+    return false;
+  }
+
+  stopInfo.watchpointIndex = bpIdx;
+  stopInfo.watchpointAddress = site.address;
+  switch (static_cast<int>(site.mode)) {
+  case BreakpointManager::kModeExec:
+    stopInfo.reason = StopInfo::kReasonBreakpoint;
+    break;
+  case BreakpointManager::kModeWrite:
+    stopInfo.reason = StopInfo::kReasonWriteWatchpoint;
+    break;
+  case BreakpointManager::kModeRead:
+    stopInfo.reason = StopInfo::kReasonReadWatchpoint;
+    break;
+  case BreakpointManager::kModeRead | BreakpointManager::kModeWrite:
+    stopInfo.reason = StopInfo::kReasonAccessWatchpoint;
+    break;
+  default:
+    DS2BUG("invalid mode");
+  }
+  return true;
+}
 } // namespace ds2

--- a/Sources/Core/SoftwareBreakpointManager.cpp
+++ b/Sources/Core/SoftwareBreakpointManager.cpp
@@ -113,4 +113,15 @@ bool SoftwareBreakpointManager::enabled(Target::Thread *thread) const {
 
   return _enabled;
 }
+
+bool SoftwareBreakpointManager::fillStopInfo(Target::Thread *thread,
+                                             StopInfo &stopInfo) {
+  BreakpointManager::Site site;
+  int bpIdx = hit(thread, site);
+  if (bpIdx < 0) {
+    return false;
+  }
+  stopInfo.reason = StopInfo::kReasonBreakpoint;
+  return true;
+}
 } // namespace ds2

--- a/Sources/Core/X86/HardwareBreakpointManager.cpp
+++ b/Sources/Core/X86/HardwareBreakpointManager.cpp
@@ -91,10 +91,16 @@ ErrorCode HardwareBreakpointManager::disableLocation(int idx,
 ErrorCode HardwareBreakpointManager::enableDebugCtrlReg(uint64_t &ctrlReg,
                                                         int idx, Mode mode,
                                                         int size) {
-  int enableIdx = 1 + (idx * 2);
+  int enableIdx = idx * 2;
+#if !defined(OS_WIN32)
+  enableIdx += 1;
+#endif
+
   int infoIdx = 16 + (idx * 4);
 
   // Set G<idx> flag
+  // Except on windows, we use L<idx> as global hardware breakpoints
+  // are disabled on Windows.
   EnableBit(ctrlReg, enableIdx);
 
   // Set R/W<idx> flags
@@ -152,8 +158,15 @@ ErrorCode HardwareBreakpointManager::enableDebugCtrlReg(uint64_t &ctrlReg,
 
 ErrorCode HardwareBreakpointManager::disableDebugCtrlReg(uint64_t &ctrlReg,
                                                          int idx) {
+  int disableIdx = idx * 2;
+#if !defined(OS_WIN32)
+  disableIdx += 1;
+#endif
+
   // Unset G<idx> flag
-  DisableBit(ctrlReg, 1 + (idx * 2));
+  // Except on windows, we use L<idx> as global hardware breakpoints
+  // are disabled on Windows.
+  DisableBit(ctrlReg, disableIdx);
 
   // Make sure to clear top half of the register
   DisableBits(ctrlReg, 32, 64);

--- a/Sources/GDBRemote/Structures.cpp
+++ b/Sources/GDBRemote/Structures.cpp
@@ -363,6 +363,9 @@ std::string StopInfo::encode(CompatibilityMode mode, bool listThreads) const {
       ss << 0;
       break;
     case StopInfo::kReasonBreakpoint:
+    case StopInfo::kReasonAccessWatchpoint:
+    case StopInfo::kReasonReadWatchpoint:
+    case StopInfo::kReasonWriteWatchpoint:
       ss << 5; // SIGTRAP
       break;
     case StopInfo::kReasonMemoryError:

--- a/Sources/Target/Windows/Thread.cpp
+++ b/Sources/Target/Windows/Thread.cpp
@@ -127,11 +127,14 @@ void Thread::updateState(DEBUG_EVENT const &de) {
 
     switch (de.u.Exception.ExceptionRecord.ExceptionCode) {
     case STATUS_BREAKPOINT:
-    case STATUS_SINGLE_STEP:
+    case STATUS_SINGLE_STEP: {
       _stopInfo.event = StopInfo::kEventStop;
-      _stopInfo.reason = StopInfo::kReasonBreakpoint;
+      auto *hwBpm = process()->hardwareBreakpointManager();
+      if (hwBpm == nullptr || !hwBpm->fillStopInfo(this, _stopInfo)) {
+        _stopInfo.reason = StopInfo::kReasonBreakpoint;
+      }
       break;
-
+    }
     case STATUS_ACCESS_VIOLATION:
     case STATUS_ARRAY_BOUNDS_EXCEEDED:
     case STATUS_IN_PAGE_ERROR:


### PR DESCRIPTION
Things this PR accomplishes:
1) Properly encoding StopInfo for watchpoints on windows
2) Switch from using global hardware breakpoints to thread-local hardware breakpoints
3) Setting the correct StopInfo on hitting a hardware breakpoint.

I'm confident (1) is correct because of the way ds2 responds on linux, so I think it should also respond the same way on windows.

I'm less sure about (2), because I'm not sure if we were using global hardware watchpoints for a specific reason. This is needed for windows support though, because windows doesn't allow the use of global hardware breakpoints as described [here](https://msdn.microsoft.com/en-us/library/windows/desktop/ms680632(v=vs.85).aspx).

I know (3) works as-is, but there's some duplication of code. My concern is that the hardware breakpoint manager's hit() method takes in a Target::Thread type, not a Target::ThreadBase. Putting this in ThreadBase doesn't work (I think).

Let me know what you think.