### PR TITLE
Handle user exceptions properly on Windows

### DIFF
--- a/Headers/DebugServer2/Types.h
+++ b/Headers/DebugServer2/Types.h
@@ -153,6 +153,7 @@ struct StopInfo {
     kReasonInstructionError,
     kReasonLibraryEvent,
     kReasonDebugOutput,
+    kReasonUserException,
 #endif
   };
 

--- a/Sources/GDBRemote/Structures.cpp
+++ b/Sources/GDBRemote/Structures.cpp
@@ -377,6 +377,9 @@ std::string StopInfo::encode(CompatibilityMode mode, bool listThreads) const {
     case StopInfo::kReasonInstructionError:
       ss << 4; // SIGILL
       break;
+    case StopInfo::kReasonUserException:
+      ss << 30; // SIGUSR1
+      break;
     default:
       DS2BUG("not implemented");
     }

--- a/Sources/Utils/Stringify.cpp
+++ b/Sources/Utils/Stringify.cpp
@@ -86,6 +86,7 @@ char const *Stringify::StopReason(StopInfo::Reason reason) {
     DO_STRINGIFY(StopInfo::kReasonInstructionError)
     DO_STRINGIFY(StopInfo::kReasonLibraryEvent)
     DO_STRINGIFY(StopInfo::kReasonDebugOutput)
+    DO_STRINGIFY(StopInfo::kReasonUserException)
 #endif
     DO_DEFAULT("unknown StopInfo reason", reason)
   }


### PR DESCRIPTION
We used to ignore these and continue the process without delivering the
exception to the user. Instead, we need to mark them appropriately and
deliver them to the inferior upon continuation.

The GDB protocol requires UNIX semantics for all interruptions so I
picked SIGUSR1 to represent user exceptions.