### PR TITLE
Disable Android-X86 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,8 @@ matrix:
       env: TARGET="Android-ARM" ANDROID_PLATFORM="16"
     - os: linux
       env: TARGET="Android-ARM64"
-    - os: linux
-      env: TARGET="Android-X86" LLDB_TESTS="all" PLATFORM="1" COVERAGE="1"
+    #- os: linux
+    #- env: TARGET="Android-X86" LLDB_TESTS="all" PLATFORM="1" COVERAGE="1"
     - os: linux
       env: TARGET="Android-X86" ANDROID_PLATFORM="16"
     - os: linux


### PR DESCRIPTION
The emulators don't seem to work for now, and I think we can live
without this target until we figure things out.