### PR TITLE
Change Travis config for Android

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
     - os: linux
       env: TARGET="Android-ARM" ANDROID_PLATFORM="16"
     - os: linux
-      env: TARGET="Android-ARM64"
+      env: TARGET="Android-ARM64" LLDB_TESTS="all" PLATFORM="1" COVERAGE="1"
     - os: linux
       env: TARGET="Android-X86"
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,8 @@ matrix:
       env: TARGET="Android-ARM" ANDROID_PLATFORM="16"
     - os: linux
       env: TARGET="Android-ARM64"
-    #- os: linux
-    #- env: TARGET="Android-X86" LLDB_TESTS="all" PLATFORM="1" COVERAGE="1"
+    - os: linux
+      env: TARGET="Android-X86"
     - os: linux
       env: TARGET="Android-X86" ANDROID_PLATFORM="16"
     - os: linux


### PR DESCRIPTION
We should re-enable android-x86 builds for API level 2x (so we're not just testing if it builds for API level 16), and we can get testing for android-arm64. Woohoo!