### PR TITLE
Adjust wrapper for RS3 headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,8 +318,17 @@ set_property(SOURCE Sources/main.cpp APPEND PROPERTY COMPILE_DEFINITIONS
 
 if ("${OS_NAME}" MATCHES "Windows")
   target_compile_definitions(ds2 PRIVATE WIN32_LEAN_AND_MEAN NOMINMAX CINTERFACE)
-  target_compile_definitions(ds2 PRIVATE WINVER=_WIN32_WINNT_WIN6
-                                         _WIN32_WINNT=_WIN32_WINNT_WIN6)
+  if (NOT CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+    # WindowsStore implies Windows 10 or above; forcing compatibility with
+    # previous Windows versions adversely affects some header definitions.
+    target_compile_definitions(ds2 PRIVATE WINVER=_WIN32_WINNT_WIN6
+                                           _WIN32_WINNT=_WIN32_WINNT_WIN6)
+  endif ()
+  if (DEFINED ENV{WindowsSDKVersion})
+    string(REPLACE "." ";" WINDOWS_SDK_VERSION_LIST "$ENV{WindowsSDKVersion}")
+    list(GET WINDOWS_SDK_VERSION_LIST 2 WINDOWS_SDK_BUILD_NUMBER)
+    target_compile_definitions(ds2 PRIVATE WINDOWS_SDK_BUILD_NUMBER=${WINDOWS_SDK_BUILD_NUMBER})
+  endif ()
 endif ()
 
 if ("${OS_NAME}" MATCHES "Linux")

--- a/Headers/DebugServer2/Host/Windows/ExtraWrappers.h
+++ b/Headers/DebugServer2/Host/Windows/ExtraWrappers.h
@@ -46,6 +46,7 @@ WINBASEAPI HANDLE WINAPI CreateRemoteThread(
   _Out_ LPDWORD                lpThreadId
 );
 
+#if WINDOWS_SDK_BUILD_NUMBER < 16299
 WINBASEAPI BOOL WINAPI GetVersionExA(
   _Inout_  LPOSVERSIONINFOA lpVersionInfo
 );
@@ -53,6 +54,7 @@ WINBASEAPI BOOL WINAPI GetVersionExW(
   _Inout_  LPOSVERSIONINFOW lpVersionInfo
 );
 #define GetVersionEx GetVersionExW
+#endif
 
 WINBASEAPI UINT WINAPI GetWindowsDirectoryA(
   _Out_ LPSTR  lpBuffer,
@@ -64,12 +66,14 @@ WINBASEAPI UINT WINAPI GetWindowsDirectoryW(
 );
 #define GetWindowsDirectory GetWindowsDirectoryW
 
+#if WINDOWS_SDK_BUILD_NUMBER < 16299
 #define EnumProcesses K32EnumProcesses
 WINBASEAPI BOOL WINAPI EnumProcesses(
   _Out_ DWORD *pProcessIds,
   _In_  DWORD cb,
   _Out_ DWORD *pBytesReturned
 );
+#endif
 
 #define EnumProcessModules    K32EnumProcessModules
 #define EnumProcessModulesEx  K32EnumProcessModulesEx
@@ -80,6 +84,7 @@ WINBASEAPI BOOL WINAPI EnumProcessModules(
   _Out_ LPDWORD lpcbNeeded
 );
 
+#if WINDOWS_SDK_BUILD_NUMBER < 16299
 #define GetModuleBaseNameA  K32GetModuleBaseNameA
 #define GetModuleBaseNameW  K32GetModuleBaseNameW
 WINBASEAPI DWORD WINAPI GetModuleBaseNameA(
@@ -111,6 +116,7 @@ WINBASEAPI DWORD WINAPI GetModuleFileNameExW(
   _In_     DWORD   nSize
 );
 #define GetModuleFileNameEx GetModuleFileNameExW
+#endif
 
 WINBASEAPI HMODULE WINAPI GetModuleHandleA(
   _In_opt_ LPCSTR lpModuleName
@@ -120,6 +126,7 @@ WINBASEAPI HMODULE WINAPI GetModuleHandleW(
 );
 #define GetModuleHandle GetModuleHandleW
 
+#if WINDOWS_SDK_BUILD_NUMBER < 16299
 WINBASEAPI BOOL WINAPI OpenProcessToken(
   _In_  HANDLE  ProcessHandle,
   _In_  DWORD   DesiredAccess,
@@ -169,9 +176,11 @@ WINBASEAPI LPWCH WINAPI GetEnvironmentStringsW(void);
 WINBASEAPI BOOL WINAPI FreeEnvironmentStringsW(
   _In_  LPWCH lpszEnvironmentBlock
 );
+#endif
 
 typedef struct PROC_THREAD_ATTRIBUTE_LIST *LPPROC_THREAD_ATTRIBUTE_LIST;
 
+#if WINDOWS_SDK_BUILD_NUMBER < 16299
 typedef struct _STARTUPINFOW {
     DWORD  cb;
     LPWSTR lpReserved;
@@ -192,12 +201,14 @@ typedef struct _STARTUPINFOW {
     HANDLE hStdOutput;
     HANDLE hStdError;
 } STARTUPINFOW, *LPSTARTUPINFOW;
+#endif
 
 typedef struct _STARTUPINFOEXW {
     STARTUPINFOW                 StartupInfo;
     LPPROC_THREAD_ATTRIBUTE_LIST lpAttributeList;
 } STARTUPINFOEXW, *LPSTARTUPINFOEXW;
 
+#if WINDOWS_SDK_BUILD_NUMBER < 16299
 typedef struct _STARTUPINFOA {
     DWORD  cb;
     LPSTR lpReserved;
@@ -268,12 +279,14 @@ WINBASEAPI VOID WINAPI ExitThread(
 WINBASEAPI DWORD WINAPI ResumeThread(
   _In_  HANDLE hThread
 );
+#endif
 
 WINBASEAPI BOOL WINAPI TerminateThread(
   _Inout_ HANDLE hThread,
   _In_    DWORD  dwExitCode
 );
 
+#if WINDOWS_SDK_BUILD_NUMBER < 16299
 WINBASEAPI DWORD WINAPI SuspendThread(
   _In_ HANDLE hThread
 );
@@ -282,12 +295,14 @@ WINBASEAPI BOOL WINAPI GetThreadContext(
   _In_     HANDLE hThread,
   _Inout_  LPCONTEXT lpContext
 );
+#endif
 
 WINBASEAPI BOOL WINAPI SetThreadContext(
   _In_  HANDLE hThread,
   _In_  const CONTEXT *lpContext
 );
 
+#if WINDOWS_SDK_BUILD_NUMBER < 16299
 WINBASEAPI int WINAPI GetThreadPriority(
   _In_  HANDLE hThread
 );
@@ -326,6 +341,7 @@ WINBASEAPI BOOL WINAPI GetExitCodeThread(
   _In_   HANDLE hThread,
   _Out_  LPDWORD lpExitCode
 );
+#endif
 
 WINBASEAPI BOOL WINAPI ReadProcessMemory(
   _In_   HANDLE hProcess,
@@ -343,11 +359,13 @@ WINBASEAPI BOOL WINAPI WriteProcessMemory(
   _Out_  SIZE_T *lpNumberOfBytesWritten
 );
 
+#if WINDOWS_SDK_BUILD_NUMBER < 16299
 WINBASEAPI BOOL WINAPI FlushInstructionCache(
   _In_ HANDLE  hProcess,
   _In_ LPCVOID lpBaseAddress,
   _In_ SIZE_T  dwSize
 );
+#endif
 
 WINBASEAPI BOOL WINAPI WaitForDebugEventEx(
   _Out_  LPDEBUG_EVENT lpDebugEvent,
@@ -360,10 +378,12 @@ WINBASEAPI BOOL WINAPI ContinueDebugEvent(
   _In_  DWORD dwContinueStatus
 );
 
+#if WINDOWS_SDK_BUILD_NUMBER < 16299
 WINBASEAPI BOOL WINAPI TerminateProcess(
   _In_  HANDLE hProcess,
   _In_  UINT uExitCode
 );
+#endif
 
 WINBASEAPI BOOL WINAPI DebugActiveProcess(
   _In_  DWORD dwProcessId
@@ -421,6 +441,7 @@ WINBASEAPI BOOL WINAPI Thread32Next(
   _Out_  LPTHREADENTRY32 lpte
 );
 
+#if WINDOWS_SDK_BUILD_NUMBER < 16299
 typedef LONG (WINAPI *PTOP_LEVEL_EXCEPTION_FILTER)(
     _In_ struct _EXCEPTION_POINTERS *ExceptionInfo
     );
@@ -430,6 +451,7 @@ typedef PTOP_LEVEL_EXCEPTION_FILTER LPTOP_LEVEL_EXCEPTION_FILTER;
 WINBASEAPI LPTOP_LEVEL_EXCEPTION_FILTER WINAPI SetUnhandledExceptionFilter(
   _In_ LPTOP_LEVEL_EXCEPTION_FILTER lpTopLevelExceptionFilter
 );
+#endif
 } // extern "C"
 // clang-format on
 


### PR DESCRIPTION
The RS3 headers expose far more APIs to store apps. Having duplicate
struct definitions causes compile errors. Having duplicate prototypes
doesn't cause compile errors, but it's still unclean and unnecessary.

Unfortunately, the Windows SDK headers don't expose any preprocessor
macro containing the SDK version number. We could use the presence of
certain other macros in the Windows headers (e.g. `NTDDI_WIN10_RS3`) as
a proxy for the SDK version, but that's ugly and significantly less
granular than the SDK version (since we'll only have one `NTDDI` macro
per Windows 10 major release, whereas there are many prerelease SDKs).
Instead, we can determine the SDK version from the environment and pass
it along to the preprocessor. This relies on the user invoking cmake
from a Visual Studio command prompt, which seems like a reasonable
assumption.

I didn't go through previous Windows SDK headers to figure out exactly
which version of the SDK these definitions were first exposed in, so the
check against 16299 might not be accurate in all cases, but it's good
enough for targeting the RS3 SDK. Other users who care about other SDK
versions can tweak the conditionals further as needed.

I also didn't bother consolidating definitions together to reduce the
amount of conditional blocks. That can be done in a follow-up if
desired.