### PR TITLE
Support Visual Studio 2017

### DIFF
--- a/Support/Scripts/build-windows.bat
+++ b/Support/Scripts/build-windows.bat
@@ -14,5 +14,10 @@
 
 @echo off
 
-call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\tools\vsvars32.bat"
+set vs2017devcmd=C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\Common7\Tools\vsdevcmd.bat
+if exist "%vs2017devcmd%" (
+    call "%vs2017devcmd%" -no_logo
+) else (
+    call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\Common7\tools\vsvars32.bat"
+)
 msbuild /nologo /verbosity:minimal /p:Configuration=Release ds2.vcxproj


### PR DESCRIPTION
Teach the runner script to look for Visual Studio 2017's development
environment setup script and fall back to 2015 otherwise.