### PR TITLE
Enable QPassSettings in lldb compat mode

### DIFF
--- a/Sources/GDBRemote/DebugSessionImpl.cpp
+++ b/Sources/GDBRemote/DebugSessionImpl.cpp
@@ -89,12 +89,12 @@ ErrorCode DebugSessionImplBase::onQuerySupported(
   localFeatures.push_back(std::string("qXfer:libraries:read+"));
 #endif
   localFeatures.push_back(std::string("QListThreadsInStopReply+"));
+  localFeatures.push_back(std::string("QPassSignals+"));
 
   if (session.mode() != kCompatibilityModeLLDB) {
     localFeatures.push_back(std::string("ConditionalBreakpoints-"));
     localFeatures.push_back(std::string("BreakpointCommands+"));
     localFeatures.push_back(std::string("multiprocess+"));
-    localFeatures.push_back(std::string("QPassSignals+"));
     localFeatures.push_back(std::string("QDisableRandomization+"));
     localFeatures.push_back(std::string("QNonStop+"));
 #if defined(OS_LINUX)


### PR DESCRIPTION
Summary: LLDB appears to support this, so let's advertise that ds2 does as well.

Test Plan:
Tested on android arm & x86:
```
< 136> send packet: $QPassSignals:04;06;07;08;0b;0e;1b;20;21;22;23;24;25;26;27;28;29;2a;2b;2c;2d;2e;2f;30;31;32;33;34;35;36;37;38;39;3a;3b;3c;3d;3e;3f;40#bb
<   6> read packet: $OK#9a
```