### PR TITLE
Do not pass-through SIGINT by default

### DIFF
--- a/Sources/Target/POSIX/Process.cpp
+++ b/Sources/Target/POSIX/Process.cpp
@@ -169,7 +169,6 @@ ds2::Target::Process *Process::Create(ProcessSpawner &spawner) {
 
 void Process::resetSignalPass() {
   _passthruSignals.clear();
-  _passthruSignals.insert(SIGINT);
 }
 
 void Process::setSignalPass(int signo, bool set) {


### PR DESCRIPTION
This was passed through by default, I assume to help with interactive
apps where the user might want to quit the app while it is being
debugged, but it seems to create problems on Android because of app
lifecycle management.