### PR TITLE
Slightly better log messages for session start/exit

### DIFF
--- a/Sources/main.cpp
+++ b/Sources/main.cpp
@@ -170,11 +170,11 @@ static int RunDebugServer(Socket *socket, SessionDelegate *impl) {
   session.setDelegate(impl);
   session.create(&qchannel);
 
-  DS2LOG(Debug, "DEBUG SERVER STARTED");
+  DS2LOG(Debug, "Debug session starting");
   thread.start();
   while (session.receive(/*cooked=*/true))
     continue;
-  DS2LOG(Debug, "DEBUG SERVER KILLED");
+  DS2LOG(Debug, "Debug session ended");
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
The word "KILLED" makes it sound like we actually got killed by a signal
or a crash even when we're doing a clean exit. This makes it more
explicit that we are terminating the debug server under "normal"
circumstances.