### PR TITLE
Remove CI builds for gcc on Darwin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,13 +79,7 @@ matrix:
     # Darwin-X86_64 targets
     - os: osx
       osx_image: xcode8.3
-      env: TARGET="Darwin-X86_64" CLANG="0"
-    - os: osx
-      osx_image: xcode8.3
       env: TARGET="Darwin-X86_64" CLANG="1"
-    - os: osx
-      osx_image: xcode9
-      env: TARGET="Darwin-X86_64" CLANG="0"
     - os: osx
       osx_image: xcode9
       env: TARGET="Darwin-X86_64" CLANG="1"


### PR DESCRIPTION
I'm under the impression most people are going to be building things on Darwin with Clang, as its a part of the default toolchain on OSX. I don't expect gcc to fail to build ds2 on Darwin if Clang works. 

Additionally, the Mac queues on Travis are frequently backed up and are a bottleneck in CI signal. Minimizing the amount of work we need to do on OSX is better imo.