### PR TITLE
Update scripts to fix Travis tests

### DIFF
--- a/Support/Scripts/common.sh
+++ b/Support/Scripts/common.sh
@@ -69,3 +69,11 @@ linux_distribution() {
     echo "unknown"
   fi
 }
+
+get_host_platform_name() {
+  case "$(uname)" in
+    "Linux")  echo "linux";;
+    "Darwin") echo "darwin";;
+    *)        die "This script only works on Linux and macOS.";;
+  esac
+}

--- a/Support/Scripts/install-android-emulator.sh
+++ b/Support/Scripts/install-android-emulator.sh
@@ -15,18 +15,13 @@ source "$(dirname "$0")/common.sh"
 
 target_arch="${1-arm}"
 
-case "$(uname)" in
-  "Linux")  platform_name="linux";;
-  "Darwin") platform_name="darwin";;
-  *)        die "This script works only on Linux and macOS.";;
-esac
-
-sdk_dir="/tmp/android-sdk-${platform_name}"
+host_platform_name=$(get_host_platform_name)
+sdk_dir="/tmp/android-sdk-${host_platform_name}"
 sdkmanager="${sdk_dir}/tools/bin/sdkmanager"
 avdmanager="${sdk_dir}/tools/bin/avdmanager"
 
 if [ ! -f "$sdkmanager" ]; then
-  package_name="sdk-tools-${platform_name}-3859397.zip"
+  package_name="sdk-tools-${host_platform_name}-3859397.zip"
   wget "https://dl.google.com/android/repository/${package_name}" -P /tmp
   unzip -d "${sdk_dir}" "/tmp/${package_name}"
   rm -f "/tmp/${package_name}"

--- a/Support/Scripts/run-lldb-tests.sh
+++ b/Support/Scripts/run-lldb-tests.sh
@@ -24,6 +24,10 @@ source "$top/Support/Scripts/common.sh"
 [ "$(uname)" == "Linux" ] || die "The lldb test suite requires a Linux host environment."
 [ -x "$build_dir/ds2" ]   || die "Unable to find a ds2 binary in the current directory."
 
+# We modify $PATH here so that the lldb testing framework can call adb
+host_platform_name=$(get_host_platform_name)
+export PATH="/tmp/android-sdk-${host_platform_name}/platform-tools:${PATH}"
+
 opt_fast=false
 opt_no_ds2_blacklists=false
 opt_log=false

--- a/Support/Testing/Travis/before-script.sh
+++ b/Support/Testing/Travis/before-script.sh
@@ -13,10 +13,7 @@ top="$(git rev-parse --show-toplevel)"
 source "$top/Support/Scripts/common.sh"
 
 if [[ "$TARGET" == Android-* && -n "${LLDB_TESTS-}" ]]; then
-  case "$(uname)" in
-    "Linux")  platform_name="linux";;
-    "Darwin") platform_name="darwin";;
-  esac
+  host_platform_name=$(get_host_platform_name)
 
   case "${TARGET}" in
     "Android-ARM") emulator_arch="emulator64-arm";;
@@ -25,7 +22,7 @@ if [[ "$TARGET" == Android-* && -n "${LLDB_TESTS-}" ]]; then
     *)             die "Unknown target '${TARGET}'.";;
   esac
 
-  sdk_dir="/tmp/android-sdk-${platform_name}"
+  sdk_dir="/tmp/android-sdk-${host_platform_name}"
   emulator="${sdk_dir}/emulator/${emulator_arch}"
   qt_lib_path="${sdk_dir}/emulator/lib64/qt/lib/"
   LD_LIBRARY_PATH="${qt_lib_path}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" "$emulator" -avd test -gpu off -no-window &

--- a/Support/Testing/Travis/before-script.sh
+++ b/Support/Testing/Travis/before-script.sh
@@ -24,7 +24,8 @@ if [[ "$TARGET" == Android-* && -n "${LLDB_TESTS-}" ]]; then
 
   sdk_dir="/tmp/android-sdk-${host_platform_name}"
   emulator="${sdk_dir}/emulator/${emulator_arch}"
+  adb="${sdk_dir}/platform-tools/adb"
   qt_lib_path="${sdk_dir}/emulator/lib64/qt/lib/"
   LD_LIBRARY_PATH="${qt_lib_path}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" "$emulator" -avd test -gpu off -no-window &
-  adb wait-for-device
+  "$adb" wait-for-device
 fi

--- a/Support/Testing/Travis/install.py
+++ b/Support/Testing/Travis/install.py
@@ -67,7 +67,6 @@ if target in android_toolchains:
                (android_toolchains[target], android_platform), shell=True)
     if os.getenv('LLDB_TESTS') != None:
         dist_packages.append('default-jdk')
-        dist_packages.append('android-tools-adb')
 
 # Running LLDB tests requires an install of lldb (for the tests to be able to
 # use the lldb python library without us building it).


### PR DESCRIPTION
The adb used by travis is too old to work with the most up-to-date emulators in the android SDK. We should use the adb that ships with the SDK instead.