### PR TITLE
Remove previously installed android NDK in case install.py flakes

### DIFF
--- a/Support/Scripts/prepare-android-ndk.sh
+++ b/Support/Scripts/prepare-android-ndk.sh
@@ -30,4 +30,5 @@ wget "https://dl.google.com/android/repository/${ndk_package_archive}"
 unzip -q "${ndk_package_archive}"
 rm -f "${ndk_package_archive}"
 
+rm -rf "$(get_android_ndk_dir)"
 mv "${ndk_package_base}" "$(get_android_ndk_dir)"


### PR DESCRIPTION
if install.py flakes because apt-get fails, this script will fail since it tries to do something that it can't. This is why the build on master is failing.