### PR TITLE
Add CircleCI build badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ds2 [![Travis Build Status](https://travis-ci.org/facebook/ds2.svg?branch=master)](https://travis-ci.org/facebook/ds2/branches) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/sdt15jwwbv2ocdlg/branch/master?svg=true)](https://ci.appveyor.com/project/a20012251/ds2/branch/master) [![Coverage Status](https://coveralls.io/repos/github/facebook/ds2/badge.svg?branch=master)](https://coveralls.io/github/facebook/ds2?branch=master)
+# ds2 [![Travis Build Status](https://travis-ci.org/facebook/ds2.svg?branch=master)](https://travis-ci.org/facebook/ds2/branches) [![CircleCI](https://circleci.com/gh/facebook/ds2.svg?style=shield)](https://circleci.com/gh/facebook/ds2) [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/sdt15jwwbv2ocdlg/branch/master?svg=true)](https://ci.appveyor.com/project/a20012251/ds2/branch/master) [![Coverage Status](https://coveralls.io/repos/github/facebook/ds2/badge.svg?branch=master)](https://coveralls.io/github/facebook/ds2?branch=master)
 
 ds2 is a debug server designed to be used with [LLDB](http://lldb.llvm.org/) to
 perform remote debugging of Linux, Android, FreeBSD, Windows and Windows Phone


### PR DESCRIPTION
Moving to CircleCI means we can add a fancy new badge to our README.md