### PR TITLE
Simplify ELFSupport::MachineTypeToCPUType

### DIFF
--- a/Sources/Host/Linux/ProcFS.cpp
+++ b/Sources/Host/Linux/ProcFS.cpp
@@ -635,11 +635,7 @@ CPUType ProcFS::GetProcessCPUType(pid_t pid) {
 
   CPUType type;
   CPUSubType subtype;
-  if (!ELFSupport::MachineTypeToCPUType(info.machine, info.is64Bit, type,
-                                        subtype)) {
-    type = kCPUTypeAny;
-  }
-
+  ELFSupport::MachineTypeToCPUType(info.machine, info.is64Bit, type, subtype);
   return type;
 }
 
@@ -779,11 +775,8 @@ bool ProcFS::ReadProcessInfo(pid_t pid, ProcessInfo &info) {
   info.realGid = gid;
   info.effectiveGid = egid;
 
-  if (!ELFSupport::MachineTypeToCPUType(elf.machine, elf.is64Bit, info.cpuType,
-                                        info.cpuSubType)) {
-    info.cpuType = kCPUTypeAny;
-    info.cpuSubType = kCPUSubTypeInvalid;
-  }
+  ELFSupport::MachineTypeToCPUType(elf.machine, elf.is64Bit, info.cpuType,
+                                   info.cpuSubType);
 
   info.nativeCPUType = elf.machine;
   info.nativeCPUSubType = kInvalidCPUType;

--- a/Sources/Support/POSIX/ELFSupport.cpp
+++ b/Sources/Support/POSIX/ELFSupport.cpp
@@ -49,9 +49,10 @@ bool ELFSupport::MachineTypeToCPUType(uint32_t machineType, bool is64Bit,
 #endif
 
   default:
+    type = kCPUTypeAny;
+    subType = kCPUSubTypeInvalid;
     return false;
   }
-
   return true;
 }
 } // namespace Support


### PR DESCRIPTION
I did this for two reason:
1) It felt strange to me that we were updating the value of `type` and `subType` if we resolved the CPUType correctly, but we otherwise left these alone... except 2 of the 3 calls changed the values to some `kCPUTypeAny` and `kCPUSubTypeInvalid` anyway. We can move these into `MachineTypeToCPUType` and avoid these 2 branches entirely.
2) Following (1), we no longer use the bool result except at one call site. It felt "dirty" to me that we were using the result of the call in some places and outright ignoring it elsewhere, so I changed the return type to `void` and instead examined what value the `type` reference had. I'm wondering what y'all think about this one.

Thoughts?