### PR TITLE
Install a newer version of CMake on docker images

### DIFF
--- a/Support/Testing/CircleCI/Dockerfile
+++ b/Support/Testing/CircleCI/Dockerfile
@@ -36,7 +36,7 @@ RUN add-apt-repository -y "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial
 RUN apt-get update
 
 # Install build dependencies
-RUN apt-get install -y cmake ninja-build
+RUN apt-get install -y ninja-build
 RUN apt-get install -y flex bison
 
 # Install x86 compilers
@@ -68,3 +68,7 @@ COPY Support/Scripts/common.sh /tmp
 COPY Support/Scripts/prepare-android-toolchain.sh /tmp
 RUN apt-get install -y unzip
 RUN /tmp/prepare-android-toolchain.sh x86 x86_64 arm arm64
+
+# Install a version of cmake that is at least the minimum version we support.
+COPY Support/Testing/CircleCI/install-cmake.sh /tmp
+RUN /tmp/install-cmake.sh

--- a/Support/Testing/CircleCI/install-cmake.sh
+++ b/Support/Testing/CircleCI/install-cmake.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+##
+## Copyright (c) 2014-present, Facebook, Inc.
+## All rights reserved.
+##
+## This source code is licensed under the University of Illinois/NCSA Open
+## Source License found in the LICENSE file in the root directory of this
+## source tree. An additional grant of patent rights can be found in the
+## PATENTS file in the same directory.
+##
+
+cmake_version="3.7"
+cmake_package_name="cmake-${cmake_version}.0-Linux-x86_64"
+cmake_archive="${cmake_package_name}.tar.gz"
+if [ ! -e "${cmake_archive}" ] ; then
+  wget --continue --output-document="/tmp/${cmake_archive}" "https://cmake.org/files/v${cmake_version}/${cmake_archive}"
+fi
+
+tar --strip-components=1 -xf "/tmp/${cmake_archive}" -C "/usr/local"


### PR DESCRIPTION
Ubuntu's official repositories have CMake version 3.5.1, but we want version 3.7 or greater. This script and Dockerfile change should allow us to build docker images with the correct version of CMake moving forward.

After we get this in, I'll push new docker images.