### PR TITLE
Move Android API level 16 builds to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ docker_config: &docker_config
 configure_step: &configure_step
   run:
     name: Configure
-    command: mkdir build && cd build && cmake -GNinja -DCMAKE_TOOLCHAIN_FILE=../Support/CMake/Toolchain-${TARGET-${CIRCLE_JOB}}.cmake ..
+    command: mkdir build && cd build && cmake -GNinja -DCMAKE_TOOLCHAIN_FILE=../Support/CMake/Toolchain-${TARGET-${CIRCLE_JOB}}.cmake ${EXTRA_CMAKE_ARGS-} ..
 
 build_step: &build_step
   run:
@@ -110,10 +110,20 @@ jobs:
     <<: *build_and_test_android
     environment:
       PLATFORM: 1
+  Android-ARM-16:
+    <<: *build_only_defaults
+    environment:
+      TARGET: Android-ARM
+      EXTRA_CMAKE_ARGS: "-DCMAKE_SYSTEM_VERSION=16"
   Android-ARM64:
     <<: *build_only_defaults
   Android-X86:
     <<: *build_only_defaults
+  Android-X86-16:
+    <<: *build_only_defaults
+    environment:
+      TARGET: Android-X86
+      EXTRA_CMAKE_ARGS: "-DCMAKE_SYSTEM_VERSION=16"
   Android-X86_64:
     <<: *build_only_defaults
   Tizen-X86:
@@ -145,8 +155,10 @@ workflows:
       - Linux-X86_64
       - Linux-X86_64-platform
       - Android-ARM
+      - Android-ARM-16
       - Android-ARM64
       - Android-X86
+      - Android-X86-16
       - Android-X86_64
       - Tizen-X86
       - Tizen-ARM

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,6 @@ env:
 matrix:
   fast_finish: true
   include:
-    # Cross-compiled targets
-    - os: linux
-      env: TARGET="Android-ARM" ANDROID_PLATFORM="16"
-    - os: linux
-      env: TARGET="Android-X86" ANDROID_PLATFORM="16"
     # Linux-X86 (with LLDB tests)
     - os: linux
       env: TARGET="Linux-X86"      LLDB_TESTS="all"  CLANG="1"


### PR DESCRIPTION
I created a new configure step. Although there's some repetition, I can't think of a better way to do this without introducing another layer of indirection (and I strongly prefer we don't introduce some wrapper script just to choose an API level properly).