### PR TITLE
Actually add the Linux platform targets to the workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,9 @@ workflows:
       - Style
       - Registers
       - Linux-X86
+      - Linux-X86-platform
       - Linux-X86_64
+      - Linux-X86_64-platform
       - Android-ARM
       - Android-ARM64
       - Android-X86


### PR DESCRIPTION
We never added these, so CircleCI wasn't running them. :(