### PR TITLE
Enable logs on CircleCI lldb tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ build_step: &build_step
 test_step: &test_step
   run:
     name: Test
-    command: cd build && ../Support/Scripts/run-${DEBUGGER-lldb}-tests.sh
+    command: cd build && ../Support/Scripts/run-${DEBUGGER-lldb}-tests.sh --log
 
 check_dirty_step: &check_dirty_step
   run:


### PR DESCRIPTION
Now that we can ssh into test machines, it would be super useful to
have logs saved from test runs