### PR TITLE
Use -rdynamic for non-static ds2 builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,9 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang"
   # be set before we include subdirectories.
   if (STATIC)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static")
+  else ()
+    # Export symbols, so that we can symbolicate backtraces
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -rdynamic")
   endif ()
 
   if (SANITIZER)


### PR DESCRIPTION
Fixes backtrace symbolication