### PR TITLE
Update instructions for running docker image locally

### DIFF
--- a/Support/Testing/CircleCI/Dockerfile
+++ b/Support/Testing/CircleCI/Dockerfile
@@ -17,7 +17,9 @@
 #
 # This hash identifies the image you just built. You can then run it locally
 # with the following command:
-#     docker run --rm -it --name ds2-testing 360abf8e6246
+#     docker run --privileged --security-opt seccomp:unconfined --rm -it --name ds2-testing 360abf8e6246
+# We run in privileged mode so that we may use ptrace to its full
+# extent as needed.
 #
 # Publishing the image for use by CircleCI is done with:
 #     docker tag 360abf8e6246 sas42/ds2-build-env


### PR DESCRIPTION
In order to more closely match CircleCI locally, we should be running the docker image slightly differently. Through experimentation and reading some discussions online, it looks like CircleCI runs the docker images in a more privileged mode. The instructions should try to match that.