### PR TITLE
Rename Type in BreakpointManager to Lifetime

### DIFF
--- a/Headers/DebugServer2/Core/BreakpointManager.h
+++ b/Headers/DebugServer2/Core/BreakpointManager.h
@@ -18,10 +18,10 @@ namespace ds2 {
 
 class BreakpointManager {
 public:
-  enum Type : unsigned int {
-    kTypePermanent = (1 << 0),
-    kTypeTemporaryOneShot = (1 << 1),
-    kTypeTemporaryUntilHit = (1 << 2),
+  enum Lifetime : unsigned int {
+    kLifetimePermanent = (1 << 0),
+    kLifetimeTemporaryOneShot = (1 << 1),
+    kLifetimeTemporaryUntilHit = (1 << 2),
   };
 
   enum Mode {
@@ -38,13 +38,13 @@ public:
 
   public:
     Address address;
-    Type type;
+    Lifetime lifetime;
     Mode mode;
     size_t size;
 
   public:
     bool operator==(Site const &other) const {
-      return (address == other.address) && (type == other.type) &&
+      return (address == other.address) && (lifetime == other.lifetime) &&
              (mode == other.mode) && (size == other.size);
     }
   };
@@ -68,7 +68,7 @@ public:
   virtual void clear();
 
 public:
-  virtual ErrorCode add(Address const &address, Type type, size_t size,
+  virtual ErrorCode add(Address const &address, Lifetime lifetime, size_t size,
                         Mode mode);
   virtual ErrorCode remove(Address const &address);
 

--- a/Headers/DebugServer2/Core/HardwareBreakpointManager.h
+++ b/Headers/DebugServer2/Core/HardwareBreakpointManager.h
@@ -22,7 +22,7 @@ public:
   ~HardwareBreakpointManager() override;
 
 public:
-  ErrorCode add(Address const &address, Type type, size_t size,
+  ErrorCode add(Address const &address, Lifetime lifetime, size_t size,
                 Mode mode) override;
   ErrorCode remove(Address const &address) override;
 

--- a/Headers/DebugServer2/Core/SoftwareBreakpointManager.h
+++ b/Headers/DebugServer2/Core/SoftwareBreakpointManager.h
@@ -51,7 +51,7 @@ public:
   enumerate(std::function<void(Site const &)> const &cb) const override;
 
 public:
-  virtual ErrorCode add(Address const &address, Type type, size_t size,
+  virtual ErrorCode add(Address const &address, Lifetime lifetime, size_t size,
                         Mode mode) override;
   virtual ErrorCode remove(Address const &address) override;
 

--- a/Sources/Architecture/ARM/SoftwareSingleStep.cpp
+++ b/Sources/Architecture/ARM/SoftwareSingleStep.cpp
@@ -338,13 +338,13 @@ ErrorCode PrepareSoftwareSingleStep(Process *process,
 
   if (branchPC != static_cast<uint32_t>(-1)) {
     DS2ASSERT(branchPCSize != 0);
-    CHK(manager->add(branchPC, BreakpointManager::kTypeTemporaryOneShot,
+    CHK(manager->add(branchPC, BreakpointManager::kLifetimeTemporaryOneShot,
                      branchPCSize, BreakpointManager::kModeExec));
   }
 
   if (nextPC != static_cast<uint32_t>(-1)) {
     DS2ASSERT(nextPCSize != 0);
-    CHK(manager->add(nextPC, BreakpointManager::kTypeTemporaryOneShot,
+    CHK(manager->add(nextPC, BreakpointManager::kLifetimeTemporaryOneShot,
                      nextPCSize, BreakpointManager::kModeExec));
   }
 

--- a/Sources/Core/ARM/SoftwareBreakpointManager.cpp
+++ b/Sources/Core/ARM/SoftwareBreakpointManager.cpp
@@ -23,8 +23,9 @@
 
 namespace ds2 {
 
-ErrorCode SoftwareBreakpointManager::add(Address const &address, Type type,
-                                         size_t size, Mode mode) {
+ErrorCode SoftwareBreakpointManager::add(Address const &address,
+                                         Lifetime lifetime, size_t size,
+                                         Mode mode) {
   if (size < 2 || size > 4) {
     bool isThumb = false;
 
@@ -56,7 +57,7 @@ ErrorCode SoftwareBreakpointManager::add(Address const &address, Type type,
     }
   }
 
-  return super::add(address.value() & ~1ULL, type, size, mode);
+  return super::add(address.value() & ~1ULL, lifetime, size, mode);
 }
 
 ErrorCode SoftwareBreakpointManager::remove(Address const &address) {

--- a/Sources/Core/HardwareBreakpointManager.cpp
+++ b/Sources/Core/HardwareBreakpointManager.cpp
@@ -24,8 +24,9 @@ HardwareBreakpointManager::HardwareBreakpointManager(
 
 HardwareBreakpointManager::~HardwareBreakpointManager() {}
 
-ErrorCode HardwareBreakpointManager::add(Address const &address, Type type,
-                                         size_t size, Mode mode) {
+ErrorCode HardwareBreakpointManager::add(Address const &address,
+                                         Lifetime lifetime, size_t size,
+                                         Mode mode) {
   if (_sites.size() >= maxWatchpoints()) {
     return kErrorInvalidArgument;
   }
@@ -36,7 +37,7 @@ ErrorCode HardwareBreakpointManager::add(Address const &address, Type type,
     mode = static_cast<Mode>(mode | kModeWrite);
   }
 
-  return super::add(address, type, size, mode);
+  return super::add(address, lifetime, size, mode);
 }
 
 ErrorCode HardwareBreakpointManager::remove(Address const &address) {

--- a/Sources/GDBRemote/DebugSessionImpl.cpp
+++ b/Sources/GDBRemote/DebugSessionImpl.cpp
@@ -1095,7 +1095,7 @@ ErrorCode DebugSessionImplBase::onInsertBreakpoint(
   if (bpm == nullptr)
     return kErrorUnsupported;
 
-  return bpm->add(address, BreakpointManager::kTypePermanent, size, mode);
+  return bpm->add(address, BreakpointManager::kLifetimePermanent, size, mode);
 }
 
 ErrorCode DebugSessionImplBase::onRemoveBreakpoint(Session &session,


### PR DESCRIPTION
It's definitely true you can use ask what type of breakpoint you have, and get back an answer concerning its lifetime (Temporary, Permanent, etc). However, we also have BreakpointType describing whether or not its a software breakpoint, hardware breakpoint, what kind of watchpoint, etc.

I think `Lifetime` is a much clearer name to describe what this is supposed to represent.