### PR TITLE
Remove assertions and add debug logs to breakpoint validation code

### DIFF
--- a/Sources/Core/ARM/HardwareBreakpointManager.cpp
+++ b/Sources/Core/ARM/HardwareBreakpointManager.cpp
@@ -37,6 +37,7 @@ size_t HardwareBreakpointManager::maxWatchpoints() {
 
 ErrorCode HardwareBreakpointManager::isValid(Address const &address,
                                              size_t size, Mode mode) const {
+  DS2LOG(Debug, "Trying to set hardware breakpoint on arm");
   return kErrorUnsupported;
 }
 } // namespace ds2

--- a/Sources/Core/ARM/SoftwareBreakpointManager.cpp
+++ b/Sources/Core/ARM/SoftwareBreakpointManager.cpp
@@ -171,7 +171,10 @@ void SoftwareBreakpointManager::getOpcode(uint32_t type,
 ErrorCode SoftwareBreakpointManager::isValid(Address const &address,
                                              size_t size, Mode mode) const {
   DS2ASSERT(mode == kModeExec);
-  DS2ASSERT((size >= 2) && (size <= 4));
+  if (size < 2 || size > 4) {
+    DS2LOG(Debug, "Received unsupported breakpoint size %zu", size);
+    return kErrorInvalidArgument;
+  }
 
   return super::isValid(address, size, mode);
 }

--- a/Sources/Core/X86/HardwareBreakpointManager.cpp
+++ b/Sources/Core/X86/HardwareBreakpointManager.cpp
@@ -214,14 +214,18 @@ ErrorCode HardwareBreakpointManager::isValid(Address const &address,
 
   case 2:
   case 4:
-    if (mode == kModeExec)
+    if (mode == kModeExec) {
       return kErrorInvalidArgument;
+    }
     break;
   default:
+    DS2LOG(Debug, "Received unsupported hardware breakpoint size %zu", size);
     return kErrorInvalidArgument;
   }
 
   if ((mode & kModeExec) && (mode & (kModeRead | kModeWrite))) {
+    DS2LOG(Debug, "Trying to set a hardware breakpoint with mixed exec and "
+                  "read/write modes");
     return kErrorInvalidArgument;
   }
 

--- a/Sources/Core/X86/SoftwareBreakpointManager.cpp
+++ b/Sources/Core/X86/SoftwareBreakpointManager.cpp
@@ -60,8 +60,11 @@ void SoftwareBreakpointManager::getOpcode(uint32_t type,
 
 ErrorCode SoftwareBreakpointManager::isValid(Address const &address,
                                              size_t size, Mode mode) const {
-  DS2ASSERT(size == 0 || size == 1);
   DS2ASSERT(mode == kModeExec);
+  if (size != 0 && size != 1) {
+    DS2LOG(Debug, "Received unsupported breakpoint size %zu", size);
+    return kErrorInvalidArgument;
+  }
 
   return super::isValid(address, size, mode);
 }


### PR DESCRIPTION
We shouldn't assert (and consequently die) when validating user input. Rather, we should just return an error and add some debug logs that lets us know that's happening.

I went through and added some logs to other breakpoint validation code as well.