### PR TITLE
Add support for choosing breakpoint sizes

### DIFF
--- a/Headers/DebugServer2/Core/BreakpointManager.h
+++ b/Headers/DebugServer2/Core/BreakpointManager.h
@@ -81,6 +81,7 @@ public:
 protected:
   virtual ErrorCode isValid(Address const &address, size_t size,
                             Mode mode) const;
+  virtual size_t chooseBreakpointSize() const = 0;
 
 protected:
   friend Target::ProcessBase;

--- a/Headers/DebugServer2/Core/HardwareBreakpointManager.h
+++ b/Headers/DebugServer2/Core/HardwareBreakpointManager.h
@@ -51,6 +51,7 @@ public:
 protected:
   ErrorCode isValid(Address const &address, size_t size,
                     Mode mode) const override;
+  size_t chooseBreakpointSize() const override;
 
 protected:
   virtual int getAvailableLocation();

--- a/Headers/DebugServer2/Core/SoftwareBreakpointManager.h
+++ b/Headers/DebugServer2/Core/SoftwareBreakpointManager.h
@@ -44,6 +44,7 @@ public:
 protected:
   ErrorCode isValid(Address const &address, size_t size,
                     Mode mode) const override;
+  size_t chooseBreakpointSize() const override;
 
 #if defined(ARCH_ARM) || defined(ARCH_ARM64)
 public:

--- a/Sources/Core/ARM/HardwareBreakpointManager.cpp
+++ b/Sources/Core/ARM/HardwareBreakpointManager.cpp
@@ -40,4 +40,9 @@ ErrorCode HardwareBreakpointManager::isValid(Address const &address,
   DS2LOG(Debug, "Trying to set hardware breakpoint on arm");
   return kErrorUnsupported;
 }
+
+size_t HardwareBreakpointManager::chooseBreakpointSize() const {
+  DS2BUG(
+      "Choosing a hardware breakpoint size on ARM is an unsupported operation");
+}
 } // namespace ds2

--- a/Sources/Core/ARM/SoftwareBreakpointManager.cpp
+++ b/Sources/Core/ARM/SoftwareBreakpointManager.cpp
@@ -178,4 +178,9 @@ ErrorCode SoftwareBreakpointManager::isValid(Address const &address,
 
   return super::isValid(address, size, mode);
 }
+
+size_t SoftwareBreakpointManager::chooseBreakpointSize() const {
+  DS2BUG(
+      "Choosing a software breakpoint size on ARM is an unsupported operation");
+}
 } // namespace ds2

--- a/Sources/Core/BreakpointManager.cpp
+++ b/Sources/Core/BreakpointManager.cpp
@@ -26,6 +26,10 @@ ErrorCode BreakpointManager::add(Address const &address, Lifetime lifetime,
                                  size_t size, Mode mode) {
   CHK(isValid(address, size, mode));
 
+  if (size == 0) {
+    size = chooseBreakpointSize();
+  }
+
   auto it = _sites.find(address);
   if (it != _sites.end()) {
     if (it->second.mode != mode)

--- a/Sources/Core/X86/HardwareBreakpointManager.cpp
+++ b/Sources/Core/X86/HardwareBreakpointManager.cpp
@@ -236,6 +236,11 @@ ErrorCode HardwareBreakpointManager::isValid(Address const &address,
   return super::isValid(address, size, mode);
 }
 
+size_t HardwareBreakpointManager::chooseBreakpointSize() const {
+  DS2BUG(
+      "Choosing a hardware breakpoint size on x86 is an unsupported operation");
+}
+
 ErrorCode HardwareBreakpointManager::readDebugRegisters(
     Target::Thread *thread, std::vector<uint64_t> &regs) const {
   Architecture::CPUState state;

--- a/Sources/Core/X86/SoftwareBreakpointManager.cpp
+++ b/Sources/Core/X86/SoftwareBreakpointManager.cpp
@@ -52,9 +52,7 @@ int SoftwareBreakpointManager::hit(Target::Thread *thread, Site &site) {
 void SoftwareBreakpointManager::getOpcode(uint32_t type,
                                           ByteVector &opcode) const {
   DS2ASSERT(type == 1);
-
   opcode.clear();
-
   opcode.push_back('\xcc'); // int 3
 }
 
@@ -67,5 +65,10 @@ ErrorCode SoftwareBreakpointManager::isValid(Address const &address,
   }
 
   return super::isValid(address, size, mode);
+}
+
+size_t SoftwareBreakpointManager::chooseBreakpointSize() const {
+  // On x86 and x86_64, software breakpoints will always be of size 1
+  return 1;
 }
 } // namespace ds2


### PR DESCRIPTION
According to the gdb-remote protocol, if the debugger does not choose an
architecture-specific size for a breakpoint, it is valid for it to send
0 as the breakpoint size. This value indicates that the debugserver
should choose a breakpoint size.

I had a workaround in #600 that I've now removed and replaced with this commit. If the all the related Linux-x86{_64,} tests pass there, this should be good to go in.