### PR TITLE
Fix x86 and x86_64 floating point register support on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,8 +47,7 @@ if ("${OS_NAME}" MATCHES "Linux" OR "${OS_NAME}" MATCHES "Android")
   set(CMAKE_REQUIRED_DEFINITIONS)
 
   include(CheckTypeSize)
-  set(CMAKE_EXTRA_INCLUDE_FILES unistd.h sys/ptrace.h sys/user.h)
-  CHECK_TYPE_SIZE("struct user_fpxregs_struct" STRUCT_USER_FPXREGS_STRUCT)
+  set(CMAKE_EXTRA_INCLUDE_FILES unistd.h sys/ptrace.h)
   CHECK_TYPE_SIZE("enum __ptrace_request" ENUM_PTRACE_REQUEST)
   set(CMAKE_EXTRA_INCLUDE_FILES)
 endif ()
@@ -330,7 +329,7 @@ endif ()
 if ("${OS_NAME}" MATCHES "Linux" OR "${OS_NAME}" MATCHES "Android")
   foreach (CHECK SYS_PERSONALITY_H GETTID POSIX_OPENPT TGKILL
            PROCESS_VM_READV PROCESS_VM_WRITEV
-           STRUCT_USER_FPXREGS_STRUCT ENUM_PTRACE_REQUEST)
+           ENUM_PTRACE_REQUEST)
     if (HAVE_${CHECK})
       target_compile_definitions(ds2 PRIVATE HAVE_${CHECK})
     endif ()

--- a/Headers/DebugServer2/Architecture/X86/CPUState.h
+++ b/Headers/DebugServer2/Architecture/X86/CPUState.h
@@ -46,6 +46,20 @@ struct X87Register {
   };
 };
 
+enum XFeature : uint64_t {
+  X86_X87 = 1 << 0,
+  X86_SSE = 1 << 1,
+  X86_AVX = 1 << 2,
+  X86_MPX_BNDREGS = 1 << 3,
+  X86_MPX_CSR = 1 << 4,
+  X86_AVX_512_OPMASK = 1 << 5,
+  X86_AVX_512_HI256 = 1 << 6,
+  X86_AVX_512_ZMM = 1 << 7,
+  X86_PROC_TRACE = 1 << 8,
+  X86_PROT_KEYS_USER_REGS = 1 << 9,
+  X86_UNKNOWN_XFEATURE = 1 << 10,
+};
+
 struct CPUState {
   union {
     uint32_t regs[16];
@@ -91,7 +105,9 @@ struct CPUState {
     } avx;
   };
 
-  // TODO - add information about xstate_hdr here
+  struct {
+    uint64_t xfeatures_mask;
+  } xsave_header;
 
   struct {
     uint32_t dr[8];
@@ -109,6 +125,7 @@ public:
   inline void clear() {
     std::memset(&gp, 0, sizeof(gp));
     std::memset(&x87, 0, sizeof(x87));
+    std::memset(&xsave_header, 0, sizeof(xsave_header));
     std::memset(&avx, 0, sizeof(avx));
     std::memset(&dr, 0, sizeof(dr));
 #if defined(OS_LINUX)

--- a/Headers/DebugServer2/Architecture/X86/CPUState.h
+++ b/Headers/DebugServer2/Architecture/X86/CPUState.h
@@ -33,17 +33,7 @@ struct AVXVector {
 };
 
 struct X87Register {
-  union {
-#if !defined(OS_WIN32)
-    // On Windows, long double and double are the same type.
-    // https://msdn.microsoft.com/en-us/library/9cx8xs15.aspx
-    long double f80;
-#endif
-    double f64;
-    float f32;
-    uint64_t mm;
-    uint8_t bytes[10];
-  };
+  uint8_t data[10];
 };
 
 enum XFeature : uint64_t {
@@ -113,6 +103,8 @@ struct CPUState {
     uint32_t dr[8];
   } dr;
 
+  uint64_t xcr0;
+
 #if defined(OS_LINUX)
   struct {
     uint32_t orig_eax;
@@ -128,6 +120,7 @@ public:
     std::memset(&xsave_header, 0, sizeof(xsave_header));
     std::memset(&avx, 0, sizeof(avx));
     std::memset(&dr, 0, sizeof(dr));
+    std::memset(&xcr0, 0, sizeof(xcr0));
 #if defined(OS_LINUX)
     std::memset(&linux_gp, 0, sizeof(linux_gp));
 #endif
@@ -306,14 +299,14 @@ public:
       _GETREG8H(gp, ch, ecx);
       _GETREG8H(gp, dh, edx);
 
-      _GETREG2(x87, st0, regs[0].bytes);
-      _GETREG2(x87, st1, regs[1].bytes);
-      _GETREG2(x87, st2, regs[2].bytes);
-      _GETREG2(x87, st3, regs[3].bytes);
-      _GETREG2(x87, st4, regs[4].bytes);
-      _GETREG2(x87, st5, regs[5].bytes);
-      _GETREG2(x87, st6, regs[6].bytes);
-      _GETREG2(x87, st7, regs[7].bytes);
+      _GETREG2(x87, st0, regs[0].data);
+      _GETREG2(x87, st1, regs[1].data);
+      _GETREG2(x87, st2, regs[2].data);
+      _GETREG2(x87, st3, regs[3].data);
+      _GETREG2(x87, st4, regs[4].data);
+      _GETREG2(x87, st5, regs[5].data);
+      _GETREG2(x87, st6, regs[6].data);
+      _GETREG2(x87, st7, regs[7].data);
       _GETREG2(x87, fstat, fstw);
       _GETREG2(x87, fctrl, fctw);
       _GETREG(x87, ftag);
@@ -371,14 +364,14 @@ public:
       _GETREG(gp, gs);
       _GETREG(gp, eflags);
 
-      _GETREG2(x87, st0, regs[0].bytes);
-      _GETREG2(x87, st1, regs[1].bytes);
-      _GETREG2(x87, st2, regs[2].bytes);
-      _GETREG2(x87, st3, regs[3].bytes);
-      _GETREG2(x87, st4, regs[4].bytes);
-      _GETREG2(x87, st5, regs[5].bytes);
-      _GETREG2(x87, st6, regs[6].bytes);
-      _GETREG2(x87, st7, regs[7].bytes);
+      _GETREG2(x87, st0, regs[0].data);
+      _GETREG2(x87, st1, regs[1].data);
+      _GETREG2(x87, st2, regs[2].data);
+      _GETREG2(x87, st3, regs[3].data);
+      _GETREG2(x87, st4, regs[4].data);
+      _GETREG2(x87, st5, regs[5].data);
+      _GETREG2(x87, st6, regs[6].data);
+      _GETREG2(x87, st7, regs[7].data);
       _GETREG2(x87, fstat, fstw);
       _GETREG2(x87, fctrl, fctw);
       _GETREG(x87, ftag);

--- a/Headers/DebugServer2/Architecture/X86_64/CPUState.h
+++ b/Headers/DebugServer2/Architecture/X86_64/CPUState.h
@@ -85,8 +85,10 @@ struct CPUState64 {
     uint16_t fstw;
     uint16_t fctw;
     uint16_t ftag;
-    uint32_t firip;
-    uint32_t forip;
+    uint32_t fioff;
+    uint32_t fiseg;
+    uint32_t fooff;
+    uint32_t foseg;
     uint16_t fop;
   } x87;
 
@@ -368,10 +370,10 @@ public:
       _GETREG2(x87, fstat, fstw);
       _GETREG2(x87, fctrl, fctw);
       _GETREG(x87, ftag);
-      _GETREG2(gp, fiseg, cs);
-      _GETREG2(x87, fioff, firip);
-      _GETREG2(gp, foseg, cs);
-      _GETREG2(x87, fooff, forip);
+      _GETREG2(x87, fiseg, fiseg);
+      _GETREG2(x87, fioff, fioff);
+      _GETREG2(x87, foseg, foseg);
+      _GETREG2(x87, fooff, fooff);
       _GETREG(x87, fop);
 
       _GETREG32(gp, eax, rax);
@@ -522,10 +524,10 @@ public:
       _GETREG2(x87, fstat, fstw);
       _GETREG2(x87, fctrl, fctw);
       _GETREG(x87, ftag);
-      _GETREG2(gp, fiseg, cs);
-      _GETREG2(x87, fioff, firip);
-      _GETREG2(gp, foseg, cs);
-      _GETREG2(x87, fooff, forip);
+      _GETREG2(x87, fiseg, fiseg);
+      _GETREG2(x87, fioff, fioff);
+      _GETREG2(x87, foseg, foseg);
+      _GETREG2(x87, fooff, fooff);
       _GETREG(x87, fop);
 
       // ymm0 maps to xmm0 for gdb

--- a/Headers/DebugServer2/Architecture/X86_64/CPUState.h
+++ b/Headers/DebugServer2/Architecture/X86_64/CPUState.h
@@ -142,6 +142,8 @@ struct CPUState64 {
     uint64_t dr[8];
   } dr;
 
+  uint64_t xcr0;
+
 #if defined(OS_LINUX)
   struct {
     uint64_t orig_rax;
@@ -159,6 +161,7 @@ public:
     std::memset(&xsave_header, 0, sizeof(xsave_header));
     std::memset(&eavx, 0, sizeof(eavx));
     std::memset(&dr, 0, sizeof(dr));
+    std::memset(&xcr0, 0, sizeof(xcr0));
 #if defined(OS_LINUX)
     std::memset(&linux_gp, 0, sizeof(linux_gp));
 #endif
@@ -363,14 +366,14 @@ public:
       _GETREG(gp, gs);
       _GETREG(gp, eflags);
 
-      _GETREG2(x87, st0, regs[0].bytes);
-      _GETREG2(x87, st1, regs[1].bytes);
-      _GETREG2(x87, st2, regs[2].bytes);
-      _GETREG2(x87, st3, regs[3].bytes);
-      _GETREG2(x87, st4, regs[4].bytes);
-      _GETREG2(x87, st5, regs[5].bytes);
-      _GETREG2(x87, st6, regs[6].bytes);
-      _GETREG2(x87, st7, regs[7].bytes);
+      _GETREG2(x87, st0, regs[0].data);
+      _GETREG2(x87, st1, regs[1].data);
+      _GETREG2(x87, st2, regs[2].data);
+      _GETREG2(x87, st3, regs[3].data);
+      _GETREG2(x87, st4, regs[4].data);
+      _GETREG2(x87, st5, regs[5].data);
+      _GETREG2(x87, st6, regs[6].data);
+      _GETREG2(x87, st7, regs[7].data);
       _GETREG2(x87, fstat, fstw);
       _GETREG2(x87, fctrl, fctw);
       _GETREG(x87, ftag);
@@ -517,14 +520,14 @@ public:
       _GETREG(gp, gs);
       _GETREG(gp, eflags);
 
-      _GETREG2(x87, st0, regs[0].bytes);
-      _GETREG2(x87, st1, regs[1].bytes);
-      _GETREG2(x87, st2, regs[2].bytes);
-      _GETREG2(x87, st3, regs[3].bytes);
-      _GETREG2(x87, st4, regs[4].bytes);
-      _GETREG2(x87, st5, regs[5].bytes);
-      _GETREG2(x87, st6, regs[6].bytes);
-      _GETREG2(x87, st7, regs[7].bytes);
+      _GETREG2(x87, st0, regs[0].data);
+      _GETREG2(x87, st1, regs[1].data);
+      _GETREG2(x87, st2, regs[2].data);
+      _GETREG2(x87, st3, regs[3].data);
+      _GETREG2(x87, st4, regs[4].data);
+      _GETREG2(x87, st5, regs[5].data);
+      _GETREG2(x87, st6, regs[6].data);
+      _GETREG2(x87, st7, regs[7].data);
       _GETREG2(x87, fstat, fstw);
       _GETREG2(x87, fctrl, fctw);
       _GETREG(x87, ftag);

--- a/Headers/DebugServer2/Architecture/X86_64/CPUState.h
+++ b/Headers/DebugServer2/Architecture/X86_64/CPUState.h
@@ -29,6 +29,7 @@ namespace X86_64 {
 using ds2::Architecture::X86::AVXVector;
 using ds2::Architecture::X86::SSEVector;
 using ds2::Architecture::X86::X87Register;
+using ds2::Architecture::X86::XFeature;
 
 struct EAVXVector {
   uint64_t value[8]; // 512-bit values
@@ -133,7 +134,9 @@ struct CPUState64 {
     } eavx;
   };
 
-  // TODO - add information about xstate_hdr here
+  struct {
+    uint64_t xfeatures_mask;
+  } xsave_header;
 
   struct {
     uint64_t dr[8];
@@ -153,6 +156,7 @@ public:
   inline void clear() {
     std::memset(&gp, 0, sizeof(gp));
     std::memset(&x87, 0, sizeof(x87));
+    std::memset(&xsave_header, 0, sizeof(xsave_header));
     std::memset(&eavx, 0, sizeof(eavx));
     std::memset(&dr, 0, sizeof(dr));
 #if defined(OS_LINUX)

--- a/Headers/DebugServer2/Host/Linux/ExtraWrappers.h
+++ b/Headers/DebugServer2/Host/Linux/ExtraWrappers.h
@@ -37,10 +37,10 @@ struct YMMHighVector {
   uint8_t value[16];
 };
 
-struct xstate_hdr {
-  uint64_t mask;
-  uint64_t reserved1[2];
-  uint64_t reserved2[5];
+struct xsave_hdr {
+  uint64_t xfeatures_mask;
+  uint64_t xcomp_bv;
+  uint64_t reserved[6];
 } DS2_ATTRIBUTE_PACKED;
 
 #if !defined(NT_X86_XSTATE)
@@ -68,13 +68,13 @@ struct user_fpxregs_struct {
 #if defined(ARCH_X86)
 struct xfpregs_struct {
   user_fpxregs_struct fpregs;
-  xstate_hdr header;
+  xsave_hdr header;
   YMMHighVector ymmh[8];
 } DS2_ATTRIBUTE_PACKED DS2_ATTRIBUTE_ALIGNED(64);
 #elif defined(ARCH_X86_64)
 struct xfpregs_struct {
   user_fpregs_struct fpregs;
-  xstate_hdr header;
+  xsave_hdr header;
   YMMHighVector ymmh[16];
 } DS2_ATTRIBUTE_PACKED DS2_ATTRIBUTE_ALIGNED(64);
 #endif

--- a/Sources/Host/FreeBSD/X86_64/PTraceX86_64.cpp
+++ b/Sources/Host/FreeBSD/X86_64/PTraceX86_64.cpp
@@ -47,8 +47,8 @@ static inline void user_to_state32(ds2::Architecture::X86_64::CPUState32 &state,
 
   uint8_t const *st_space = reinterpret_cast<uint8_t const *>(user.fpr_acc);
   for (size_t n = 0; n < 8; n++) {
-    memcpy(state.x87.regs[n].bytes, st_space + n * 10,
-           sizeof(state.x87.regs[n].bytes));
+    memcpy(state.x87.regs[n].data, st_space + n * 10,
+           sizeof(state.x87.regs[n].data));
   }
 
   //
@@ -82,8 +82,8 @@ state32_to_user(struct fpreg &user,
 
   uint8_t *st_space = reinterpret_cast<uint8_t *>(user.fpr_acc);
   for (size_t n = 0; n < 8; n++) {
-    memcpy(st_space + n * 10, state.x87.regs[n].bytes,
-           sizeof(state.x87.regs[n].bytes));
+    memcpy(st_space + n * 10, state.x87.regs[n].data,
+           sizeof(state.x87.regs[n].data));
   }
 
   //
@@ -112,7 +112,6 @@ static inline void user_to_state64(ds2::Architecture::X86_64::CPUState64 &state,
   state.x87.fstw = x87->en_sw;
   state.x87.fctw = x87->en_cw;
   state.x87.ftag = x87->en_tw;
-  state.x87.firip = x87->en_fip;
 
   // state.x87.fop = user.r_fop;
   // state.x87.firip = user.r_rip;
@@ -120,8 +119,8 @@ static inline void user_to_state64(ds2::Architecture::X86_64::CPUState64 &state,
 
   uint8_t const *st_space = reinterpret_cast<uint8_t const *>(user.fpr_acc);
   for (size_t n = 0; n < 8; n++) {
-    memcpy(state.x87.regs[n].bytes, st_space + n * 10,
-           sizeof(state.x87.regs[n].bytes));
+    memcpy(state.x87.regs[n].data, st_space + n * 10,
+           sizeof(state.x87.regs[n].data));
   }
 
   //
@@ -152,8 +151,8 @@ state64_to_user(struct fpreg &user,
 
   uint8_t *st_space = reinterpret_cast<uint8_t *>(user.fpr_acc);
   for (size_t n = 0; n < 8; n++) {
-    memcpy(st_space + n * 16, state.x87.regs[n].bytes,
-           sizeof(state.x87.regs[n].bytes));
+    memcpy(st_space + n * 16, state.x87.regs[n].data,
+           sizeof(state.x87.regs[n].data));
   }
 
   //

--- a/Sources/Host/Linux/X86/PTraceX86.cpp
+++ b/Sources/Host/Linux/X86/PTraceX86.cpp
@@ -21,93 +21,112 @@
 
 #define super ds2::Host::POSIX::PTrace
 
+using ds2::Architecture::X86::XFeature;
+
 namespace ds2 {
 namespace Host {
 namespace Linux {
 
 static inline void user_to_state32(ds2::Architecture::X86::CPUState &state,
-                                   struct xfpregs_struct const &xfpregs) {
-  // X87 State
-  state.x87.fstw = xfpregs.fpregs.swd;
-  state.x87.fctw = xfpregs.fpregs.cwd;
-  state.x87.ftag = xfpregs.fpregs.twd;
+                                   struct xsave_struct const &xfpregs) {
+  // Legacy (fxsave) registers
+  state.x87.fctw = xfpregs.fpregs.fctw;
+  state.x87.fstw = xfpregs.fpregs.fstw;
+  state.x87.ftag = xfpregs.fpregs.ftag;
   state.x87.fop = xfpregs.fpregs.fop;
-  state.x87.fiseg = xfpregs.fpregs.fcs;
-  state.x87.fioff = xfpregs.fpregs.fip;
-  state.x87.foseg = xfpregs.fpregs.fos;
-  state.x87.fooff = xfpregs.fpregs.foo;
+  state.x87.fioff = xfpregs.fpregs.fioff;
+  state.x87.fiseg = xfpregs.fpregs.fiseg;
+  state.x87.fooff = xfpregs.fpregs.fooff;
+  state.x87.foseg = xfpregs.fpregs.foseg;
 
   auto st_space = reinterpret_cast<uint8_t const *>(xfpregs.fpregs.st_space);
-  static const size_t x87Size = sizeof(state.x87.regs[0].bytes);
+  static const size_t x87DataSize = sizeof(state.x87.regs[0].data);
+  static const size_t x87RegSize = x87DataSize + x87Padding;
   for (size_t n = 0; n < array_sizeof(state.x87.regs); n++) {
-    memcpy(state.x87.regs[n].bytes, st_space + n * x87Size, x87Size);
+    memcpy(state.x87.regs[n].data, st_space + n * x87RegSize, x87DataSize);
   }
 
-  // SSE state
   state.sse.mxcsr = xfpregs.fpregs.mxcsr;
-  state.sse.mxcsrmask = xfpregs.fpregs.reserved;
+  state.sse.mxcsrmask = xfpregs.fpregs.mxcsrmask;
   auto xmm_space = reinterpret_cast<uint8_t const *>(xfpregs.fpregs.xmm_space);
-  static const size_t sseSize = sizeof(state.sse.regs[0]);
+  static const size_t sseRegSize = sizeof(state.sse.regs[0]);
   for (size_t n = 0; n < array_sizeof(state.sse.regs); n++) {
-    memcpy(&state.sse.regs[n], xmm_space + n * sseSize, sseSize);
+    memcpy(&state.sse.regs[n], xmm_space + n * sseRegSize, sseRegSize);
   }
+
+  state.xcr0 = xfpregs.fpregs.xcr0;
+
+  // XSAVE Header
+  state.xsave_header.xfeatures_mask = xfpregs.header.xfeatures_mask;
 
   //
   //  EAVX State
   //
   auto ymmh = reinterpret_cast<uint8_t const *>(xfpregs.ymmh);
   static const size_t avxSize = sizeof(state.avx.regs[0]);
-  static const size_t ymmhSize = avxSize - sseSize;
+  static const size_t ymmhSize = avxSize - sseRegSize;
   for (size_t n = 0; n < array_sizeof(state.avx.regs); n++) {
-    auto avxHigh = reinterpret_cast<uint8_t *>(&state.avx.regs[n]) + sseSize;
+    auto avxHigh = reinterpret_cast<uint8_t *>(&state.avx.regs[n]) + sseRegSize;
     memcpy(avxHigh, ymmh + n * ymmhSize, ymmhSize);
   }
-
-  state.xsave_header.xfeatures_mask = xfpregs.header.xfeatures_mask;
 }
 
 static inline void
-state32_to_user(struct xfpregs_struct &xfpregs,
+state32_to_user(struct xsave_struct &xfpregs,
                 ds2::Architecture::X86::CPUState const &state) {
-  // X87 State
-  xfpregs.fpregs.swd = state.x87.fstw;
-  xfpregs.fpregs.cwd = state.x87.fctw;
-  xfpregs.fpregs.twd = state.x87.ftag;
+  // Legacy (fxsave) registers
+  xfpregs.fpregs.fctw = state.x87.fctw;
+  xfpregs.fpregs.fstw = state.x87.fstw;
+  xfpregs.fpregs.ftag = state.x87.ftag;
   xfpregs.fpregs.fop = state.x87.fop;
-  xfpregs.fpregs.fcs = state.x87.fiseg;
-  xfpregs.fpregs.fip = state.x87.fioff;
-  xfpregs.fpregs.fos = state.x87.foseg;
-  xfpregs.fpregs.foo = state.x87.fooff;
+  xfpregs.fpregs.fioff = state.x87.fioff;
+  xfpregs.fpregs.fiseg = state.x87.fiseg;
+  xfpregs.fpregs.fooff = state.x87.fooff;
+  xfpregs.fpregs.foseg = state.x87.foseg;
 
   auto st_space = reinterpret_cast<uint8_t *>(xfpregs.fpregs.st_space);
-  static const size_t x87Size = sizeof(state.x87.regs[0].bytes);
+  static const size_t x87DataSize = sizeof(state.x87.regs[0].data);
+  static const size_t x87RegSize = x87DataSize + x87Padding;
   for (size_t n = 0; n < array_sizeof(state.x87.regs); n++) {
-    memcpy(st_space + n * x87Size, state.x87.regs[n].bytes, x87Size);
+    memcpy(st_space + n * x87RegSize, state.x87.regs[n].data, x87DataSize);
   }
 
-  // SSE state
   xfpregs.fpregs.mxcsr = state.sse.mxcsr;
-  xfpregs.fpregs.reserved = state.sse.mxcsrmask;
+  xfpregs.fpregs.mxcsrmask = state.sse.mxcsrmask;
   auto xmm_space = reinterpret_cast<uint8_t *>(xfpregs.fpregs.xmm_space);
-  static const size_t sseSize = sizeof(state.sse.regs[0]);
+  static const size_t sseRegSize = sizeof(state.sse.regs[0]);
   for (size_t n = 0; n < array_sizeof(state.sse.regs); n++) {
-    memcpy(xmm_space + n * sseSize, &state.sse.regs[n], sseSize);
+    memcpy(xmm_space + n * sseRegSize, &state.sse.regs[n], sseRegSize);
   }
+
+  xfpregs.fpregs.xcr0 = state.xcr0;
+
+  // XSAVE Header
+  xfpregs.header.xfeatures_mask = state.xsave_header.xfeatures_mask;
+  if (state.xcr0 & XFeature::X86_X87) {
+    xfpregs.header.xfeatures_mask |= XFeature::X86_X87;
+  }
+  if (state.xcr0 & XFeature::X86_SSE) {
+    xfpregs.header.xfeatures_mask |= XFeature::X86_SSE;
+  }
+  if (state.xcr0 & XFeature::X86_AVX) {
+    xfpregs.header.xfeatures_mask |= XFeature::X86_AVX;
+  }
+  // TODO: Support xcomp_bv. See 13.4.2 XSAVE Header in Intel's 64 and IA32
+  // Architecture Manual to understand the purpose of xcomp_bv.
+  xfpregs.header.xcomp_bv = 0;
 
   //
   //  EAVX State
   //
   auto ymmh = reinterpret_cast<uint8_t *>(xfpregs.ymmh);
   static const size_t avxSize = sizeof(state.avx.regs[0]);
-  static const size_t ymmhSize = avxSize - sseSize;
+  static const size_t ymmhSize = avxSize - sseRegSize;
   for (size_t n = 0; n < array_sizeof(state.avx.regs); n++) {
     auto avxHigh =
-        reinterpret_cast<const uint8_t *>(&state.avx.regs[n]) + sseSize;
+        reinterpret_cast<const uint8_t *>(&state.avx.regs[n]) + sseRegSize;
     memcpy(ymmh + n * ymmhSize, avxHigh, ymmhSize);
   }
-
-  xfpregs.header.xfeatures_mask = state.xsave_header.xfeatures_mask;
-  xfpregs.header.xcomp_bv = 0;
 }
 
 ErrorCode PTrace::readCPUState(ProcessThreadId const &ptid, ProcessInfo const &,
@@ -125,15 +144,19 @@ ErrorCode PTrace::readCPUState(ProcessThreadId const &ptid, ProcessInfo const &,
   Architecture::X86::user_to_state32(state, gprs);
 
   //
-  // Read SSE and AVX
+  // Read xregs (x87, mmx, sse, avx)
   //
-  struct xfpregs_struct xfpregs;
+  struct xsave_struct xfpregs;
   struct iovec fpregs_iovec;
   fpregs_iovec.iov_base = &xfpregs;
   fpregs_iovec.iov_len = sizeof(xfpregs);
 
+  // TODO: If this fails (i.e. ptrace returns < 0), it means XSAVE is most
+  // likely unsupported and we can't expect XSAVE to work. In this case, we
+  // should fallback to FXSAVE and only read the legacy portion of our xsave
+  // state (x87, MMX, SSE).
   // If this call fails, don't return failure, since AVX may not be available
-  // on this CPU
+  // on this CPU.
   if (wrapPtrace(PTRACE_GETREGSET, pid, NT_X86_XSTATE, &fpregs_iovec) == 0) {
     user_to_state32(state, xfpregs);
   }
@@ -176,15 +199,19 @@ ErrorCode PTrace::writeCPUState(ProcessThreadId const &ptid,
     return Platform::TranslateError();
 
   //
-  // Write SSE and AVX
+  // Write xregs (x87, mmx, sse, avx)
   //
-  struct xfpregs_struct xfpregs;
+  struct xsave_struct xfpregs;
   struct iovec fpregs_iovec;
   fpregs_iovec.iov_base = &xfpregs;
   fpregs_iovec.iov_len = sizeof(xfpregs);
 
   state32_to_user(xfpregs, state);
 
+  // TODO: If this fails (i.e. ptrace returns < 0), it means XSAVE is most
+  // likely unsupported and we can't expect XSAVE to work. In this case, we
+  // should fallback to FXSAVE and only write the legacy portion of our xsave
+  // state (x87, MMX, SSE)
   wrapPtrace(PTRACE_SETREGSET, pid, NT_X86_XSTATE, &fpregs_iovec);
 
   // Write the debug registers

--- a/Sources/Host/Linux/X86_64/PTraceX86_64.cpp
+++ b/Sources/Host/Linux/X86_64/PTraceX86_64.cpp
@@ -66,6 +66,8 @@ static inline void user_to_state32(ds2::Architecture::X86_64::CPUState32 &state,
     auto avxHigh = reinterpret_cast<uint8_t *>(&state.avx.regs[n]) + sseSize;
     memcpy(avxHigh, ymmh + n * ymmhSize, ymmhSize);
   }
+
+  state.xsave_header.xfeatures_mask = xfpregs.header.xfeatures_mask;
 }
 
 static inline void
@@ -111,6 +113,9 @@ state32_to_user(struct xfpregs_struct &xfpregs,
         reinterpret_cast<const uint8_t *>(&state.avx.regs[n]) + sseSize;
     memcpy(ymmh + n * ymmhSize, avxHigh, ymmhSize);
   }
+
+  xfpregs.header.xfeatures_mask = state.xsave_header.xfeatures_mask;
+  xfpregs.header.xcomp_bv = 0;
 }
 
 //
@@ -165,6 +170,8 @@ static inline void user_to_state64(ds2::Architecture::X86_64::CPUState64 &state,
     auto avxHigh = reinterpret_cast<uint8_t *>(&state.avx.regs[n]) + sseSize;
     memcpy(avxHigh, ymmh + n * ymmhSize, ymmhSize);
   }
+
+  state.xsave_header.xfeatures_mask = xfpregs.header.xfeatures_mask;
 }
 
 static inline void
@@ -217,6 +224,9 @@ state64_to_user(struct xfpregs_struct &xfpregs,
         reinterpret_cast<const uint8_t *>(&state.avx.regs[n]) + sseSize;
     memcpy(ymmh + n * ymmhSize, avxHigh, ymmhSize);
   }
+
+  xfpregs.header.xfeatures_mask = state.xsave_header.xfeatures_mask;
+  xfpregs.header.xcomp_bv = 0;
 }
 
 ErrorCode PTrace::readCPUState(ProcessThreadId const &ptid,
@@ -315,13 +325,6 @@ ErrorCode PTrace::writeCPUState(ProcessThreadId const &ptid,
   struct iovec fpregs_iovec;
   fpregs_iovec.iov_base = &xfpregs;
   fpregs_iovec.iov_len = sizeof(xfpregs);
-
-  // We need this read to fill the kernel header (xfpregs_struct.xstate_hdr)
-  // TODO - add this header to CPUState so we don't need this read
-  if (wrapPtrace(PTRACE_GETREGSET, pid, NT_X86_XSTATE, &fpregs_iovec) < 0) {
-    // If we fail to read the AVX register info, still write the SSE regs
-    fpregs_iovec.iov_len = sizeof(xfpregs.fpregs);
-  }
 
   if (state.is32) {
     state32_to_user(xfpregs, state.state32);

--- a/Sources/Host/Linux/X86_64/PTraceX86_64.cpp
+++ b/Sources/Host/Linux/X86_64/PTraceX86_64.cpp
@@ -21,183 +21,183 @@
 
 #define super ds2::Host::POSIX::PTrace
 
+using ds2::Architecture::X86::XFeature;
+
 namespace ds2 {
 namespace Host {
 namespace Linux {
 
 static inline void user_to_state32(ds2::Architecture::X86_64::CPUState32 &state,
-                                   struct xfpregs_struct const &xfpregs) {
-  //
-  // X87 State
-  //
-  state.x87.fstw = xfpregs.fpregs.swd;
-  state.x87.fctw = xfpregs.fpregs.cwd;
-  state.x87.ftag = xfpregs.fpregs.ftw;
+                                   struct xsave_struct const &xfpregs) {
+  // Legacy (fxsave) registers
+  state.x87.fctw = xfpregs.fpregs.fctw;
+  state.x87.fstw = xfpregs.fpregs.fstw;
+  state.x87.ftag = xfpregs.fpregs.ftag;
   state.x87.fop = xfpregs.fpregs.fop;
-  state.x87.fiseg = xfpregs.fpregs.rip >> 32;
-  state.x87.fioff = xfpregs.fpregs.rip;
-  state.x87.foseg = xfpregs.fpregs.rdp >> 32;
-  state.x87.fooff = xfpregs.fpregs.rdp;
+  state.x87.fioff = xfpregs.fpregs.fioff;
+  state.x87.fiseg = xfpregs.fpregs.fiseg;
+  state.x87.fooff = xfpregs.fpregs.fooff;
+  state.x87.foseg = xfpregs.fpregs.foseg;
 
   auto st_space = reinterpret_cast<uint8_t const *>(xfpregs.fpregs.st_space);
-  static const size_t x87Size = sizeof(state.x87.regs[0].bytes);
+  static const size_t x87DataSize = sizeof(state.x87.regs[0].data);
+  static const size_t x87RegSize = x87DataSize + x87Padding;
   for (size_t n = 0; n < array_sizeof(state.x87.regs); n++) {
-    memcpy(state.x87.regs[n].bytes, st_space + n * x87Size, x87Size);
+    memcpy(state.x87.regs[n].data, st_space + n * x87RegSize, x87DataSize);
   }
 
-  //
-  // SSE State
-  //
   state.sse.mxcsr = xfpregs.fpregs.mxcsr;
-  state.sse.mxcsrmask = xfpregs.fpregs.mxcr_mask;
+  state.sse.mxcsrmask = xfpregs.fpregs.mxcsrmask;
   auto xmm_space = reinterpret_cast<uint8_t const *>(xfpregs.fpregs.xmm_space);
-  static const size_t sseSize = sizeof(state.sse.regs[0]);
+  static const size_t sseRegSize = sizeof(state.sse.regs[0]);
   for (size_t n = 0; n < array_sizeof(state.sse.regs); n++) {
-    memcpy(&state.sse.regs[n], xmm_space + n * sseSize, sseSize);
+    memcpy(&state.sse.regs[n], xmm_space + n * sseRegSize, sseRegSize);
   }
+
+  state.xcr0 = xfpregs.fpregs.xcr0;
+
+  // XSAVE Header
+  state.xsave_header.xfeatures_mask = xfpregs.header.xfeatures_mask;
 
   //
   //  EAVX State
   //
   auto ymmh = reinterpret_cast<uint8_t const *>(xfpregs.ymmh);
   static const size_t avxSize = sizeof(state.avx.regs[0]);
-  static const size_t ymmhSize = avxSize - sseSize;
+  static const size_t ymmhSize = avxSize - sseRegSize;
   for (size_t n = 0; n < array_sizeof(state.avx.regs); n++) {
-    auto avxHigh = reinterpret_cast<uint8_t *>(&state.avx.regs[n]) + sseSize;
+    auto avxHigh = reinterpret_cast<uint8_t *>(&state.avx.regs[n]) + sseRegSize;
     memcpy(avxHigh, ymmh + n * ymmhSize, ymmhSize);
   }
-
-  state.xsave_header.xfeatures_mask = xfpregs.header.xfeatures_mask;
 }
 
 static inline void
-state32_to_user(struct xfpregs_struct &xfpregs,
+state32_to_user(struct xsave_struct &xfpregs,
                 ds2::Architecture::X86_64::CPUState32 const &state) {
-  //
-  // X87 State
-  //
-  xfpregs.fpregs.swd = state.x87.fstw;
-  xfpregs.fpregs.cwd = state.x87.fctw;
-  xfpregs.fpregs.ftw = state.x87.ftag;
+  // Legacy (fxsave) registers
+  xfpregs.fpregs.fctw = state.x87.fctw;
+  xfpregs.fpregs.fstw = state.x87.fstw;
+  xfpregs.fpregs.ftag = state.x87.ftag;
   xfpregs.fpregs.fop = state.x87.fop;
-  xfpregs.fpregs.rip =
-      (static_cast<uint64_t>(state.x87.fiseg) << 32) | state.x87.fioff;
-  xfpregs.fpregs.rdp =
-      (static_cast<uint64_t>(state.x87.foseg) << 32) | state.x87.fooff;
+  xfpregs.fpregs.fioff = state.x87.fioff;
+  xfpregs.fpregs.fiseg = state.x87.fiseg;
+  xfpregs.fpregs.fooff = state.x87.fooff;
+  xfpregs.fpregs.foseg = state.x87.foseg;
 
   auto st_space = reinterpret_cast<uint8_t *>(xfpregs.fpregs.st_space);
-  static const size_t x87Size = sizeof(state.x87.regs[0].bytes);
+  static const size_t x87DataSize = sizeof(state.x87.regs[0].data);
+  static const size_t x87RegSize = x87DataSize + x87Padding;
   for (size_t n = 0; n < array_sizeof(state.x87.regs); n++) {
-    memcpy(st_space + n * x87Size, state.x87.regs[n].bytes, x87Size);
+    memcpy(st_space + n * x87RegSize, state.x87.regs[n].data, x87DataSize);
   }
 
-  //
-  // SSE State
-  //
   xfpregs.fpregs.mxcsr = state.sse.mxcsr;
-  xfpregs.fpregs.mxcr_mask = state.sse.mxcsrmask;
+  xfpregs.fpregs.mxcsrmask = state.sse.mxcsrmask;
   auto xmm_space = reinterpret_cast<uint8_t *>(xfpregs.fpregs.xmm_space);
-  static const size_t sseSize = sizeof(state.sse.regs[0]);
+  static const size_t sseRegSize = sizeof(state.sse.regs[0]);
   for (size_t n = 0; n < array_sizeof(state.sse.regs); n++) {
-    memcpy(xmm_space + n * sseSize, &state.sse.regs[n], sseSize);
+    memcpy(xmm_space + n * sseRegSize, &state.sse.regs[n], sseRegSize);
   }
+
+  xfpregs.fpregs.xcr0 = state.xcr0;
+
+  // XSAVE Header
+  xfpregs.header.xfeatures_mask = state.xsave_header.xfeatures_mask;
+  if (state.xcr0 & XFeature::X86_X87) {
+    xfpregs.header.xfeatures_mask |= XFeature::X86_X87;
+  }
+  if (state.xcr0 & XFeature::X86_SSE) {
+    xfpregs.header.xfeatures_mask |= XFeature::X86_SSE;
+  }
+  if (state.xcr0 & XFeature::X86_AVX) {
+    xfpregs.header.xfeatures_mask |= XFeature::X86_AVX;
+  }
+  // TODO: Support xcomp_bv. See 13.4.2 XSAVE Header in Intels' 64 and IA32
+  // Architecture Manual to understand the purpose of xcomp_bv.
+  xfpregs.header.xcomp_bv = 0;
 
   //
   //  EAVX State
   //
   auto ymmh = reinterpret_cast<uint8_t *>(xfpregs.ymmh);
   static const size_t avxSize = sizeof(state.avx.regs[0]);
-  static const size_t ymmhSize = avxSize - sseSize;
+  static const size_t ymmhSize = avxSize - sseRegSize;
   for (size_t n = 0; n < array_sizeof(state.avx.regs); n++) {
     auto avxHigh =
-        reinterpret_cast<const uint8_t *>(&state.avx.regs[n]) + sseSize;
+        reinterpret_cast<const uint8_t *>(&state.avx.regs[n]) + sseRegSize;
     memcpy(ymmh + n * ymmhSize, avxHigh, ymmhSize);
   }
-
-  xfpregs.header.xfeatures_mask = state.xsave_header.xfeatures_mask;
-  xfpregs.header.xcomp_bv = 0;
 }
-
-//
-// 64-bit helpers
-//
 
 static inline void user_to_state64(ds2::Architecture::X86_64::CPUState64 &state,
-                                   struct xfpregs_struct const &xfpregs) {
-  //
-  // X87 State
-  //
-  state.x87.fstw = xfpregs.fpregs.swd;
-  state.x87.fctw = xfpregs.fpregs.cwd;
-  state.x87.ftag = xfpregs.fpregs.ftw;
+                                   struct xsave_struct const &xfpregs) {
+  // Legacy (fxsave) registers
+  state.x87.fctw = xfpregs.fpregs.fctw;
+  state.x87.fstw = xfpregs.fpregs.fstw;
+  state.x87.ftag = xfpregs.fpregs.ftag;
   state.x87.fop = xfpregs.fpregs.fop;
-  state.x87.fiseg = xfpregs.fpregs.rip >> 32;
-  state.x87.fioff = xfpregs.fpregs.rip & 0xFFFFFFFF;
-  state.x87.foseg = xfpregs.fpregs.rdp >> 32;
-  state.x87.fooff = xfpregs.fpregs.rdp & 0xFFFFFFFF;
+  state.x87.fioff = xfpregs.fpregs.fioff;
+  state.x87.fiseg = xfpregs.fpregs.fiseg;
+  state.x87.fooff = xfpregs.fpregs.fooff;
+  state.x87.foseg = xfpregs.fpregs.foseg;
 
   auto st_space = reinterpret_cast<uint8_t const *>(xfpregs.fpregs.st_space);
-  static const size_t x87Size = sizeof(state.x87.regs[0].bytes);
+  static const size_t x87DataSize = sizeof(state.x87.regs[0].data);
+  static const size_t x87RegSize = x87DataSize + x87Padding;
   for (size_t n = 0; n < array_sizeof(state.x87.regs); n++) {
-    memcpy(state.x87.regs[n].bytes, st_space + n * x87Size, x87Size);
+    memcpy(state.x87.regs[n].data, st_space + n * x87RegSize, x87DataSize);
   }
 
-  //
-  // SSE State
-  //
-
-  // This hack is necessary because we don't handle EAVX registers
+  // TODO: This hack is necessary because we don't handle EAVX registers.
   size_t numSSEState = array_sizeof(state.sse.regs);
   size_t numSSEUser =
       sizeof(xfpregs.fpregs.xmm_space) / sizeof(state.sse.regs[0]);
   size_t numSSE = std::min(numSSEState, numSSEUser);
 
   state.sse.mxcsr = xfpregs.fpregs.mxcsr;
-  state.sse.mxcsrmask = xfpregs.fpregs.mxcr_mask;
+  state.sse.mxcsrmask = xfpregs.fpregs.mxcsrmask;
   auto xmm_space = reinterpret_cast<uint8_t const *>(xfpregs.fpregs.xmm_space);
-  static const size_t sseSize = sizeof(state.sse.regs[0]);
+  static const size_t sseRegSize = sizeof(state.sse.regs[0]);
   for (size_t n = 0; n < numSSE; n++) {
-    memcpy(&state.sse.regs[n], xmm_space + n * sseSize, sseSize);
+    memcpy(&state.sse.regs[n], xmm_space + n * sseRegSize, sseRegSize);
   }
+
+  state.xcr0 = xfpregs.fpregs.xcr0;
+
+  // XSAVE Header
+  state.xsave_header.xfeatures_mask = xfpregs.header.xfeatures_mask;
 
   //
   //  EAVX State
   //
   auto ymmh = reinterpret_cast<uint8_t const *>(xfpregs.ymmh);
   static const size_t avxSize = sizeof(state.avx.regs[0]);
-  static const size_t ymmhSize = avxSize - sseSize;
+  static const size_t ymmhSize = avxSize - sseRegSize;
   for (size_t n = 0; n < numSSE; n++) {
-    auto avxHigh = reinterpret_cast<uint8_t *>(&state.avx.regs[n]) + sseSize;
+    auto avxHigh = reinterpret_cast<uint8_t *>(&state.avx.regs[n]) + sseRegSize;
     memcpy(avxHigh, ymmh + n * ymmhSize, ymmhSize);
   }
-
-  state.xsave_header.xfeatures_mask = xfpregs.header.xfeatures_mask;
 }
 
 static inline void
-state64_to_user(struct xfpregs_struct &xfpregs,
+state64_to_user(struct xsave_struct &xfpregs,
                 ds2::Architecture::X86_64::CPUState64 const &state) {
-  //
-  // X87 State
-  //
-  xfpregs.fpregs.swd = state.x87.fstw;
-  xfpregs.fpregs.cwd = state.x87.fctw;
-  xfpregs.fpregs.ftw = state.x87.ftag;
+  // Legacy (fxsave) registers
+  xfpregs.fpregs.fctw = state.x87.fctw;
+  xfpregs.fpregs.fstw = state.x87.fstw;
+  xfpregs.fpregs.ftag = state.x87.ftag;
   xfpregs.fpregs.fop = state.x87.fop;
-  xfpregs.fpregs.rip =
-      (static_cast<uint64_t>(state.x87.fiseg) << 32) | state.x87.fioff;
-  xfpregs.fpregs.rdp =
-      (static_cast<uint64_t>(state.x87.foseg) << 32) | state.x87.fooff;
+  xfpregs.fpregs.fiseg = state.x87.fiseg;
+  xfpregs.fpregs.fioff = state.x87.fioff;
+  xfpregs.fpregs.foseg = state.x87.foseg;
+  xfpregs.fpregs.fooff = state.x87.fooff;
 
   auto st_space = reinterpret_cast<uint8_t *>(xfpregs.fpregs.st_space);
-  static const size_t x87Size = sizeof(state.x87.regs[0].bytes);
+  static const size_t x87DataSize = sizeof(state.x87.regs[0].data);
+  static const size_t x87RegSize = x87DataSize + x87Padding;
   for (size_t n = 0; n < array_sizeof(state.x87.regs); n++) {
-    memcpy(st_space + n * x87Size, state.x87.regs[n].bytes, x87Size);
+    memcpy(st_space + n * x87RegSize, state.x87.regs[n].data, x87DataSize);
   }
-
-  //
-  // SSE State
-  //
 
   // This hack is necessary because we don't handle EAVX registers
   size_t numSSEState = array_sizeof(state.sse.regs);
@@ -206,27 +206,41 @@ state64_to_user(struct xfpregs_struct &xfpregs,
   size_t numSSE = std::min(numSSEState, numSSEUser);
 
   xfpregs.fpregs.mxcsr = state.sse.mxcsr;
-  xfpregs.fpregs.mxcr_mask = state.sse.mxcsrmask;
+  xfpregs.fpregs.mxcsrmask = state.sse.mxcsrmask;
   auto xmm_space = reinterpret_cast<uint8_t *>(xfpregs.fpregs.xmm_space);
-  static const size_t sseSize = sizeof(state.sse.regs[0]);
+  static const size_t sseRegSize = sizeof(state.sse.regs[0]);
   for (size_t n = 0; n < numSSE; n++) {
-    memcpy(xmm_space + n * sseSize, &state.sse.regs[n], sseSize);
+    memcpy(xmm_space + n * sseRegSize, &state.sse.regs[n], sseRegSize);
   }
+
+  xfpregs.fpregs.xcr0 = state.xcr0;
+
+  // XSAVE Header
+  xfpregs.header.xfeatures_mask = state.xsave_header.xfeatures_mask;
+  if (state.xcr0 & XFeature::X86_X87) {
+    xfpregs.header.xfeatures_mask |= XFeature::X86_X87;
+  }
+  if (state.xcr0 & XFeature::X86_SSE) {
+    xfpregs.header.xfeatures_mask |= XFeature::X86_SSE;
+  }
+  if (state.xcr0 & XFeature::X86_AVX) {
+    xfpregs.header.xfeatures_mask |= XFeature::X86_AVX;
+  }
+  // TODO: Support xcomp_bv. See 13.4.2 XSAVE Header in Intels' 64 and IA32
+  // Architecture Manual to understand the purpose of xcomp_bv.
+  xfpregs.header.xcomp_bv = 0;
 
   //
   //  EAVX State
   //
   auto ymmh = reinterpret_cast<uint8_t *>(xfpregs.ymmh);
   static const size_t avxSize = sizeof(state.avx.regs[0]);
-  static const size_t ymmhSize = avxSize - sseSize;
+  static const size_t ymmhSize = avxSize - sseRegSize;
   for (size_t n = 0; n < numSSE; n++) {
     auto avxHigh =
-        reinterpret_cast<const uint8_t *>(&state.avx.regs[n]) + sseSize;
+        reinterpret_cast<const uint8_t *>(&state.avx.regs[n]) + sseRegSize;
     memcpy(ymmh + n * ymmhSize, avxHigh, ymmhSize);
   }
-
-  xfpregs.header.xfeatures_mask = state.xsave_header.xfeatures_mask;
-  xfpregs.header.xcomp_bv = 0;
 }
 
 ErrorCode PTrace::readCPUState(ProcessThreadId const &ptid,
@@ -253,13 +267,17 @@ ErrorCode PTrace::readCPUState(ProcessThreadId const &ptid,
   //
   // Read SSE and AVX
   //
-  struct xfpregs_struct xfpregs;
+  struct xsave_struct xfpregs;
   struct iovec fpregs_iovec;
   fpregs_iovec.iov_base = &xfpregs;
   fpregs_iovec.iov_len = sizeof(xfpregs);
 
+  // TODO: If this fails (i.e. ptrace returns < 0), it means XSAVE is most
+  // likely unsupported and we can't expect XSAVE to work. In this case, we
+  // should fallback to FXSAVE and only read the legacy portion of our xsave
+  // state (x87, MMX, SSE).
   // If this call fails, don't return failure, since AVX may not be available
-  // on this CPU
+  // on this CPU.
   if (wrapPtrace(PTRACE_GETREGSET, pid, NT_X86_XSTATE, &fpregs_iovec) == 0) {
     if (pinfo.pointerSize == sizeof(uint32_t)) {
       user_to_state32(state.state32, xfpregs);
@@ -321,7 +339,7 @@ ErrorCode PTrace::writeCPUState(ProcessThreadId const &ptid,
   //
   // Write SSE and AVX
   //
-  struct xfpregs_struct xfpregs;
+  struct xsave_struct xfpregs;
   struct iovec fpregs_iovec;
   fpregs_iovec.iov_base = &xfpregs;
   fpregs_iovec.iov_len = sizeof(xfpregs);
@@ -332,6 +350,10 @@ ErrorCode PTrace::writeCPUState(ProcessThreadId const &ptid,
     state64_to_user(xfpregs, state.state64);
   }
 
+  // TODO: If this fails (i.e. ptrace returns < 0), it means XSAVE is most
+  // likely unsupported and we can't expect XSAVE to work. In this case, we
+  // should fallback to FXSAVE and only write the legacy portion of our xsave
+  // state (x87, MMX, SSE).
   wrapPtrace(PTRACE_SETREGSET, pid, NT_X86_XSTATE, &fpregs_iovec);
 
   // Write the debug registers

--- a/Sources/Host/Linux/X86_64/PTraceX86_64.cpp
+++ b/Sources/Host/Linux/X86_64/PTraceX86_64.cpp
@@ -126,8 +126,10 @@ static inline void user_to_state64(ds2::Architecture::X86_64::CPUState64 &state,
   state.x87.fctw = xfpregs.fpregs.cwd;
   state.x87.ftag = xfpregs.fpregs.ftw;
   state.x87.fop = xfpregs.fpregs.fop;
-  state.x87.firip = xfpregs.fpregs.rip;
-  state.x87.forip = xfpregs.fpregs.rdp;
+  state.x87.fiseg = xfpregs.fpregs.rip >> 32;
+  state.x87.fioff = xfpregs.fpregs.rip & 0xFFFFFFFF;
+  state.x87.foseg = xfpregs.fpregs.rdp >> 32;
+  state.x87.fooff = xfpregs.fpregs.rdp & 0xFFFFFFFF;
 
   auto st_space = reinterpret_cast<uint8_t const *>(xfpregs.fpregs.st_space);
   static const size_t x87Size = sizeof(state.x87.regs[0].bytes);
@@ -175,8 +177,10 @@ state64_to_user(struct xfpregs_struct &xfpregs,
   xfpregs.fpregs.cwd = state.x87.fctw;
   xfpregs.fpregs.ftw = state.x87.ftag;
   xfpregs.fpregs.fop = state.x87.fop;
-  xfpregs.fpregs.rip = state.x87.firip;
-  xfpregs.fpregs.rdp = state.x87.forip;
+  xfpregs.fpregs.rip =
+      (static_cast<uint64_t>(state.x87.fiseg) << 32) | state.x87.fioff;
+  xfpregs.fpregs.rdp =
+      (static_cast<uint64_t>(state.x87.foseg) << 32) | state.x87.fooff;
 
   auto st_space = reinterpret_cast<uint8_t *>(xfpregs.fpregs.st_space);
   static const size_t x87Size = sizeof(state.x87.regs[0].bytes);

--- a/Sources/Target/Windows/X86/ThreadX86.cpp
+++ b/Sources/Target/Windows/X86/ThreadX86.cpp
@@ -67,8 +67,8 @@ ErrorCode Thread::readCPUState(Architecture::CPUState &state) {
   uint8_t const *st_space =
       reinterpret_cast<uint8_t const *>(context.FloatSave.RegisterArea);
   for (size_t n = 0; n < 8; n++) {
-    static const int reg_size = sizeof(state.x87.regs[0].bytes);
-    memcpy(state.x87.regs[n].bytes, st_space + n * reg_size, reg_size);
+    memcpy(state.x87.regs[n].data, st_space + n * sizeof(state.x87.regs[n]),
+           sizeof(state.x87.regs[n].data));
   }
 
   // SSE state


### PR DESCRIPTION
I understand this is a big change, and will probably require a lot of time to digest. I'm sure there are a few improvements to be made in implementation, but I think the fundamental idea is correct.

I refactored this in the process of fixing TestRegisters. I believe our previous implementation of dealing with floating point registers was incorrect. I have refactored the code to fix at least some of the problems, but not all. I think I have fixed the following:
- fiseg/fioff/foseg/fooff were incorrectly aliased on x86_64. Especially strange given fiseg/foseg were aliased to cs.
- No support for xstate_header, and therefore no way of enabling features (e.g. x87, sse, avx) through the features mask.
- Incorrect read/writes to stmm registers. Specifically, we did not account for 6 bytes of padding between each stmm register in user_fpxregs_struct. This meant that we were reading from and writing to buffer space.
- user_fpxregs_struct fields are now defined with explicit sizes.
- Not handling xcr0 at all, meaning we never could tell what features were actually enabled.

There are a few things I did not fix, but I added TODOs to revisit. These are not especially critical and would make for great beginner tasks for ds2.
- Support xcomp_bv field in xstate_header.
- Fall back to FXSAVE when XSAVE fails.
