### PR TITLE
Re-enable TestFloatTypes

### DIFF
--- a/Support/Testing/Blacklists/ds2/llvm_60.blacklist
+++ b/Support/Testing/Blacklists/ds2/llvm_60.blacklist
@@ -5,6 +5,5 @@ TestProcessIO.ProcessIOTestCase.test_stdout_redirection
 TestProcessIO.ProcessIOTestCase.test_stdout_stderr_redirection
 TestIntegerTypes.IntegerTypesTestCase
 TestIntegerTypesExpr.IntegerTypesExprTestCase
-TestFloatTypes.FloatTypesTestCase
 TestFloatTypesExpr.FloatTypesExprTestCase
 TestSettings.SettingsCommandTestCase


### PR DESCRIPTION
This test was disabled as a part of moving to 6.0. I'd like to re-enable it. The first step is removing it from the blacklist to see what breaks, which is what this PR will do initially.