### PR TITLE
Refactor support for using lldb-server in run-lldb-tests.sh

### DIFF
--- a/Support/Scripts/run-lldb-tests.sh
+++ b/Support/Scripts/run-lldb-tests.sh
@@ -230,7 +230,7 @@ if [[ "${PLATFORM-}" = "1" ]]; then
     args+=("--excluded" "$blacklist_dir/ds2/platform.blacklist")
   fi
 
-  server_args=("p" "--server" "--listen" "$server_port")
+  server_args=("p" "--server" "--listen" "*:$server_port")
 
   if ! $opt_use_lldb_server && $opt_log; then
     server_args+=("--remote-debug" "--log-file=$working_dir/$(basename "$server_path").log")

--- a/Support/Scripts/run-lldb-tests.sh
+++ b/Support/Scripts/run-lldb-tests.sh
@@ -21,17 +21,10 @@ top="$(git rev-parse --show-toplevel)"
 build_dir="$PWD"
 
 source "$top/Support/Scripts/common.sh"
-
-[ "$(uname)" == "Linux" ] || die "The lldb test suite requires a Linux host environment."
-[ -x "$build_dir/ds2" ]   || die "Unable to find a ds2 binary in the current directory."
-
-# We modify $PATH here so that the lldb testing framework can call adb
 host_platform_name=$(get_host_platform_name)
-export PATH="/tmp/android-sdk-${host_platform_name}/platform-tools:${PATH}"
 
-if [[ "$TARGET" == Android-* ]]; then
-  adb wait-for-device
-fi
+[ "${host_platform_name}" == "linux" ] || die "The lldb test suite requires a Linux host environment."
+[ -x "$build_dir/ds2" ]   || die "Unable to find a ds2 binary in the current directory."
 
 opt_fast=false
 opt_no_ds2_blacklists=false
@@ -52,7 +45,11 @@ for o in "$@"; do
   esac
 done
 
+# We modify $PATH here so that the lldb testing framework can call adb
+export PATH="/tmp/android-sdk-${host_platform_name}/platform-tools:${PATH}"
+
 if [[ "${TARGET-}" = Android-* ]]; then
+  adb wait-for-device
   platform_name="android"
 else
   platform_name="linux"


### PR DESCRIPTION
I did some refactoring, because it's not enough to just not set LLDB_DEBUGSERVER_PATH. instead, the idea is to set it to lldb-server-6.0.

I didn't add support for using lldb-server and the `--log` flag at the same time (since lldb-server does logging differently than ds2) but I bet it wouldn't be too hard to implement if we cared to see what lldb-server does.

I've run both the test suite with both ds2 and lldb-server. Surprisingly lldb-server has more failures, but the test suite ran on both.

Additionally I shuffled some code around.