### PR TITLE
Reblacklist TestFloatTypes

### DIFF
--- a/Support/Testing/Blacklists/ds2/llvm_60.blacklist
+++ b/Support/Testing/Blacklists/ds2/llvm_60.blacklist
@@ -5,5 +5,6 @@ TestProcessIO.ProcessIOTestCase.test_stdout_redirection
 TestProcessIO.ProcessIOTestCase.test_stdout_stderr_redirection
 TestIntegerTypes.IntegerTypesTestCase
 TestIntegerTypesExpr.IntegerTypesExprTestCase
+TestFloatTypes.FloatTypesTestCase
 TestFloatTypesExpr.FloatTypesExprTestCase
 TestSettings.SettingsCommandTestCase


### PR DESCRIPTION
I want to re-blacklist TestFloatTypes for Linux platform mode. It flakes.