### PR TITLE
Re-enable TestEnumTypes

### DIFF
--- a/Support/Testing/Blacklists/ds2/general.blacklist
+++ b/Support/Testing/Blacklists/ds2/general.blacklist
@@ -13,7 +13,6 @@ TestLldbGdbServer.LldbGdbServerTestCase.test_attach_commandline_continue_app_exi
 
 skip
 test_lldbmi
-EnumTypesTestCase
 TestCallWithTimeout.ExprCommandWithTimeoutsTestCase
 TestCreateAfterAttach
 TestGdbRemoteAuxvSupport.TestGdbRemoteAuxvSupport


### PR DESCRIPTION
I'm going to just see how CircleCI reacts. It passed on Linux-X86_64 locally.