### PR TITLE
Update Linux::Process to use Linux::PTrace instead of POSIX::PTrace

### DIFF
--- a/Headers/DebugServer2/Target/Linux/Process.h
+++ b/Headers/DebugServer2/Target/Linux/Process.h
@@ -53,7 +53,7 @@ public:
   ErrorCode wait() override;
 
 public:
-  Host::POSIX::PTrace &ptrace() const override;
+  Host::Linux::PTrace &ptrace() const override;
 
 protected:
   ErrorCode updateInfo() override;

--- a/Sources/Target/Linux/Process.cpp
+++ b/Sources/Target/Linux/Process.cpp
@@ -319,7 +319,7 @@ bool Process::isAlive() const {
   return super::isAlive();
 }
 
-ds2::Host::POSIX::PTrace &Process::ptrace() const {
+ds2::Host::Linux::PTrace &Process::ptrace() const {
   return const_cast<Process *>(this)->_ptrace;
 }
 


### PR DESCRIPTION
`Linux::Process` holds a `Linux::PTrace` yet has a method that returns a `POSIX::PTrace`.

Change `Linux::Process::PTrace() const` to return a `Linux::PTrace` instead of a `POSIX::PTrace`.