### PR TITLE
Implement Linux::PTrace::getClonedTID(ProcessID, unsigned long&) method to be used to call ptrace(3) with PTRACE_GETEVENTMSG in the case of a tracee clone(3) call

### DIFF
--- a/Headers/DebugServer2/Host/POSIX/PTrace.h
+++ b/Headers/DebugServer2/Host/POSIX/PTrace.h
@@ -76,6 +76,8 @@ public:
                            ProcessInfo const &pinfo, int signal = 0,
                            Address const &address = Address());
 
+  virtual ErrorCode getClonedTID(ProcessId pid, unsigned long &clonedTID);
+
 public:
   virtual ErrorCode getSigInfo(ProcessThreadId const &ptid, siginfo_t &si) = 0;
 


### PR DESCRIPTION
Upon a tracee calling `clone(3)`, the tracer can call `ptrace(3)` with the `PTRACE_GETEVENTMSG` flag to receive the `tid` of the newly cloned thread.

Implement a method, `Linux::PTrace::getClonedTID` to be called after a clone event that sets the value of `clonedTID` to the newly cloned child's `tid`. 