### PR TITLE
Modify Linux::Process::wait() to account for a race condition involving a simultaneous clone & step

### DIFF
--- a/Headers/DebugServer2/Host/Linux/PTrace.h
+++ b/Headers/DebugServer2/Host/Linux/PTrace.h
@@ -66,6 +66,7 @@ public:
 
 public:
   ErrorCode getSigInfo(ProcessThreadId const &ptid, siginfo_t &si) override;
+  ErrorCode getEventMessage(ProcessThreadId const &ptid, unsigned long &data);
 
 protected:
   virtual ErrorCode readRegisterSet(ProcessThreadId const &ptid, int regSetCode,

--- a/Sources/Host/Linux/PTrace.cpp
+++ b/Sources/Host/Linux/PTrace.cpp
@@ -285,6 +285,17 @@ ErrorCode PTrace::getSigInfo(ProcessThreadId const &ptid, siginfo_t &si) {
   return kSuccess;
 }
 
+ErrorCode PTrace::getEventMessage(ProcessThreadId const &ptid,
+                                  unsigned long &data) {
+  pid_t pid;
+  CHK(ptidToPid(ptid, pid));
+
+  if (wrapPtrace(PTRACE_GETEVENTMSG, pid, nullptr, &data) < 0)
+    return Platform::TranslateError();
+
+  return kSuccess;
+}
+
 ErrorCode PTrace::readRegisterSet(ProcessThreadId const &ptid, int regSetCode,
                                   void *buffer, size_t length) {
   struct iovec iov = {buffer, length};

--- a/Sources/Target/Linux/Thread.cpp
+++ b/Sources/Target/Linux/Thread.cpp
@@ -84,6 +84,7 @@ ErrorCode Thread::updateStopInfo(int waitStatus) {
 
     if (waitStatus >> 8 == (SIGTRAP | (PTRACE_EVENT_CLONE << 8))) { // (1)
       _stopInfo.event = StopInfo::kEventNone;
+      _stopInfo.reason = StopInfo::kReasonThreadSpawn;
     } else if (si.si_code == SI_TKILL && si.si_pid == getpid()) { // (2)
       // The only signal we are supposed to send to the inferior is a SIGSTOP.
       DS2ASSERT(_stopInfo.signal == SIGSTOP);

--- a/Support/Scripts/run-lldb-tests.sh
+++ b/Support/Scripts/run-lldb-tests.sh
@@ -163,9 +163,6 @@ fi
 if [ -n "${TARGET-}" ]; then
   if [[ "${TARGET}" == "Linux-X86_64" || "${TARGET}" == "Linux-X86_64-Clang" ]]; then
     args+=("--arch=x86_64")
-    if ! $opt_no_ds2_blacklists; then
-      args+=("--excluded" "$blacklist_dir/ds2/x86_64.blacklist")
-    fi
     if [[ "${PLATFORM-}" = "1" ]]; then
       args+=("--excluded" "$blacklist_dir/ds2/llvm_60.blacklist")
     fi

--- a/Support/Testing/Blacklists/ds2/x86_64.blacklist
+++ b/Support/Testing/Blacklists/ds2/x86_64.blacklist
@@ -1,2 +1,0 @@
-xfail
-TestCreateDuringInstructionStep.CreateDuringInstructionStepTestCase.test_step_inst


### PR DESCRIPTION
It is possible for the inferior to experience a (roughly) simultaneous
SIGTRAP from stepping while also receiving a SIGTRAP/SIGSTOP pair from a
clone(3) call. Depending on the receiving order of the signals, ds2
could handle the situation improperly and miss out on the existance of
the cloned thread.

Modify the processing logic to check if we are simultaneously
experiencing a thread being stepped while that thread also calls
clone and, if so, handle the cloned child at within the function instead
of depending on the normal waitpid loop.