### PR TITLE
Add support in run-lldb-tests.sh to exclude centos tests

### DIFF
--- a/Support/Scripts/run-lldb-tests.sh
+++ b/Support/Scripts/run-lldb-tests.sh
@@ -155,6 +155,9 @@ fi
 
 if ! $opt_no_ds2_blacklists; then
   args+=("--excluded" "$blacklist_dir/ds2/general.blacklist")
+  if [ "$(linux_distribution)" == "centos" ]; then
+    args+=("--excluded" "$blacklist_dir/ds2/centos.blacklist")
+  fi
 fi
 
 if [ -n "${TARGET-}" ]; then


### PR DESCRIPTION
`FAIL: TestExprs2.ExprCommands2TestCase.test_more_expr_commands_dwarf (expression_command/test/TestExprs2.py)`

consistently occurs on master. Add this to follow up with a centos.blacklists addition to hide this flake. 