### PR TITLE
Pass -no-audio to android emulator

### DIFF
--- a/Support/Scripts/start-android-emulator.sh
+++ b/Support/Scripts/start-android-emulator.sh
@@ -27,4 +27,4 @@ sdk_dir="/tmp/android-sdk-${host_platform_name}"
 emulator="${sdk_dir}/emulator/${emulator_arch}"
 adb="${sdk_dir}/platform-tools/adb"
 qt_lib_path="${sdk_dir}/emulator/lib64/qt/lib/"
-LD_LIBRARY_PATH="${qt_lib_path}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" "$emulator" -avd "android-test-${arch}" -gpu off -no-window -no-accel
+LD_LIBRARY_PATH="${qt_lib_path}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" "$emulator" -avd "android-test-${arch}" -gpu off -no-window -no-accel -no-audio


### PR DESCRIPTION
The emulator complains about not being able to use audio resources properly. We can disable it just like we disable graphics too.