### PR TITLE
Change the way we launch platform mode in test script

### DIFF
--- a/Support/Scripts/run-lldb-tests.sh
+++ b/Support/Scripts/run-lldb-tests.sh
@@ -233,7 +233,7 @@ if [[ "${PLATFORM-}" = "1" ]]; then
     args+=("--excluded" "$blacklist_dir/ds2/platform.blacklist")
   fi
 
-  server_args=("p" "--server" "--listen" "*:$server_port")
+  server_args=("p" "--server" "--listen" "localhost:$server_port")
 
   if ! $opt_use_lldb_server && $opt_log; then
     server_args+=("--remote-debug" "--log-file=$working_dir/$(basename "$server_path").log")


### PR DESCRIPTION
Instead of passing `*:$server_port` to the `--listen` flag, we can try to pass something else. In this case I'm trying out `localhost:$server_port`. I'm changing this because the android emulator we have on our Docker image does not like it when we try to launch with `*:$server_port`. :(

I tried locally for Android-ARM and the test suite actually starts running. I've also tried on Linux-X86_64 using lldb-server and it also works (the test suite starts running, at least). I'm hoping CircleCI will catch any failures actually running the test suite, even if some tests fail. :)