### PR TITLE
Change run-lldb-tests.sh to use 127.0.0.1 instead of localhost or *

### DIFF
--- a/Support/Scripts/run-lldb-tests.sh
+++ b/Support/Scripts/run-lldb-tests.sh
@@ -233,7 +233,7 @@ if [[ "${PLATFORM-}" = "1" ]]; then
     args+=("--excluded" "$blacklist_dir/ds2/platform.blacklist")
   fi
 
-  server_args=("p" "--server" "--listen" "*:$server_port")
+  server_args=("p" "--server" "--listen" "127.0.0.1:$server_port")
 
   if ! $opt_use_lldb_server && $opt_log; then
     server_args+=("--remote-debug" "--log-file=$working_dir/$(basename "$server_path").log")


### PR DESCRIPTION
Android-ARM is failing to create a socket given localhost or * as the
address. Darwin is definitively failing on `::getaddrinfo` when fed *.
So, for now:

Change run-lldb-tests.sh to use 127.0.0.1 instead of localhost or *
as the argument for the address for the socket connection