### PR TITLE
Add setting to always save compile_commands.json file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@
 
 cmake_minimum_required(VERSION 3.7)
 cmake_policy(SET CMP0054 NEW)
+set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 
 project(DebugServer2)
 


### PR DESCRIPTION
It seems standard in llvm projects (e.g. llvm, swift) to have this just set to 1. 