### PR TITLE
Kill BreakpointManager::enable/disable

### DIFF
--- a/Headers/DebugServer2/Core/BreakpointManager.h
+++ b/Headers/DebugServer2/Core/BreakpointManager.h
@@ -36,6 +36,7 @@ public:
   struct Site {
   protected:
     friend class BreakpointManager;
+    friend class SoftwareBreakpointManager;
     int32_t refs;
 
   public:
@@ -95,10 +96,6 @@ public:
   // Returns the hardware index of the breakpoint, if applicable.
   // If not hit, returns a negative integer
   virtual int hit(Target::Thread *thread, Site &site) = 0;
-
-public:
-  virtual void enable(Target::Thread *thread = nullptr);
-  virtual void disable(Target::Thread *thread = nullptr);
 
 protected:
   virtual ErrorCode enableLocation(Site const &site,

--- a/Headers/DebugServer2/Core/BreakpointManager.h
+++ b/Headers/DebugServer2/Core/BreakpointManager.h
@@ -102,7 +102,6 @@ protected:
                                    Target::Thread *thread = nullptr) = 0;
   virtual ErrorCode disableLocation(Site const &site,
                                     Target::Thread *thread = nullptr) = 0;
-  virtual bool enabled(Target::Thread *thread = nullptr) const = 0;
 
 public:
   virtual bool fillStopInfo(Target::Thread *thread, StopInfo &stopInfo) = 0;

--- a/Headers/DebugServer2/Core/HardwareBreakpointManager.h
+++ b/Headers/DebugServer2/Core/HardwareBreakpointManager.h
@@ -38,15 +38,14 @@ protected:
                             Target::Thread *thread = nullptr) override;
   virtual ErrorCode disableLocation(int idx, Target::Thread *thread);
 
+public:
+  ErrorCode addThread(Target::Thread *thread);
+
 protected:
   bool enabled(Target::Thread *thread = nullptr) const override;
 
 public:
   virtual size_t maxWatchpoints();
-
-public:
-  void enable(Target::Thread *thread = nullptr) override;
-  void disable(Target::Thread *thread = nullptr) override;
 
 protected:
   ErrorCode isValid(Address const &address, size_t size,

--- a/Headers/DebugServer2/Core/HardwareBreakpointManager.h
+++ b/Headers/DebugServer2/Core/HardwareBreakpointManager.h
@@ -41,9 +41,6 @@ protected:
 public:
   ErrorCode addThread(Target::Thread *thread);
 
-protected:
-  bool enabled(Target::Thread *thread = nullptr) const override;
-
 public:
   virtual size_t maxWatchpoints();
 
@@ -68,7 +65,6 @@ protected:
 
 protected:
   std::vector<uint64_t> _locations;
-  std::unordered_set<ThreadId> _enabled;
 
 #if defined(ARCH_X86) || defined(ARCH_X86_64)
 protected:

--- a/Headers/DebugServer2/Core/SoftwareBreakpointManager.h
+++ b/Headers/DebugServer2/Core/SoftwareBreakpointManager.h
@@ -38,8 +38,8 @@ protected:
                                     Target::Thread *thread = nullptr) override;
 
 public:
-  void enable(Target::Thread *thread = nullptr) override;
-  void disable(Target::Thread *thread = nullptr) override;
+  void enable(Target::Thread *thread = nullptr);
+  void disable(Target::Thread *thread = nullptr);
 
 protected:
   ErrorCode isValid(Address const &address, size_t size,

--- a/Headers/DebugServer2/Core/SoftwareBreakpointManager.h
+++ b/Headers/DebugServer2/Core/SoftwareBreakpointManager.h
@@ -16,7 +16,6 @@ namespace ds2 {
 class SoftwareBreakpointManager : public BreakpointManager {
 private:
   std::map<uint64_t, ByteVector> _insns;
-  bool _enabled;
 
 public:
   SoftwareBreakpointManager(Target::ProcessBase *process);
@@ -27,6 +26,7 @@ public:
 
 public:
   virtual int hit(Target::Thread *thread, Site &site) override;
+  void afterResume();
 
 protected:
   virtual void getOpcode(uint32_t type, ByteVector &opcode) const;
@@ -36,10 +36,6 @@ protected:
                                    Target::Thread *thread = nullptr) override;
   virtual ErrorCode disableLocation(Site const &site,
                                     Target::Thread *thread = nullptr) override;
-
-public:
-  void enable(Target::Thread *thread = nullptr);
-  void disable(Target::Thread *thread = nullptr);
 
 protected:
   ErrorCode isValid(Address const &address, size_t size,
@@ -63,8 +59,6 @@ public:
 public:
   virtual bool has(Address const &address) const override;
 #endif
-
-  virtual bool enabled(Target::Thread *thread = nullptr) const override;
 
 public:
   virtual bool fillStopInfo(Target::Thread *thread,

--- a/Headers/DebugServer2/Core/SoftwareBreakpointManager.h
+++ b/Headers/DebugServer2/Core/SoftwareBreakpointManager.h
@@ -46,6 +46,10 @@ protected:
                     Mode mode) const override;
   size_t chooseBreakpointSize() const override;
 
+public:
+  void insertStashedInsns(Address const &start, size_t length,
+                          ByteVector &data);
+
 #if defined(ARCH_ARM) || defined(ARCH_ARM64)
 public:
   virtual void

--- a/Sources/Core/BreakpointManager.cpp
+++ b/Sources/Core/BreakpointManager.cpp
@@ -49,11 +49,7 @@ ErrorCode BreakpointManager::add(Address const &address, Lifetime lifetime,
     site.mode = mode;
     site.size = size;
 
-    // If the breakpoint manager is already in enabled state, enable
-    // the newly added breakpoint too.
-    if (enabled()) {
-      return enableLocation(site);
-    }
+    return enableLocation(site);
   }
 
   return kSuccess;
@@ -90,14 +86,7 @@ ErrorCode BreakpointManager::remove(Address const &address) {
 
 do_remove:
   DS2ASSERT(it->second.refs == 0);
-  //
-  // If the breakpoint manager is already in enabled state, disable
-  // the newly removed breakpoint too.
-  //
-  ErrorCode error = kSuccess;
-  if (enabled()) {
-    error = disableLocation(it->second);
-  }
+  ErrorCode error = disableLocation(it->second);
 
   _sites.erase(it);
   return error;

--- a/Sources/Core/BreakpointManager.cpp
+++ b/Sources/Core/BreakpointManager.cpp
@@ -117,43 +117,6 @@ void BreakpointManager::enumerate(
   }
 }
 
-void BreakpointManager::enable(Target::Thread *thread) {
-  //
-  // Both callbacks should be installed by child class before
-  // enabling the breakpoint manager.
-  //
-  if (enabled(thread)) {
-    DS2LOG(Warning, "double-enabling breakpoints");
-  }
-
-  enumerate([this, thread](Site const &site) { enableLocation(site, thread); });
-}
-
-void BreakpointManager::disable(Target::Thread *thread) {
-  if (!enabled(thread)) {
-    DS2LOG(Warning, "double-disabling breakpoints");
-  }
-
-  enumerate(
-      [this, thread](Site const &site) { disableLocation(site, thread); });
-
-  //
-  // Remove temporary breakpoints.
-  //
-  auto it = _sites.begin();
-  while (it != _sites.end()) {
-    it->second.lifetime = it->second.lifetime & ~Lifetime::TemporaryOneShot;
-    if (it->second.lifetime == Lifetime::None) {
-      // refs should always be 0 unless we have a Lifetime::Permanent
-      // breakpoint.
-      DS2ASSERT(it->second.refs == 0);
-      _sites.erase(it++);
-    } else {
-      it++;
-    }
-  }
-}
-
 bool BreakpointManager::hit(Address const &address, Site &site) {
   if (!address.valid())
     return false;

--- a/Sources/Core/HardwareBreakpointManager.cpp
+++ b/Sources/Core/HardwareBreakpointManager.cpp
@@ -129,11 +129,6 @@ ErrorCode HardwareBreakpointManager::addThread(Target::Thread *thread) {
   return kSuccess;
 }
 
-// Hardware breakpoints are always enabled
-bool HardwareBreakpointManager::enabled(Target::Thread *thread) const {
-  return true;
-}
-
 bool HardwareBreakpointManager::fillStopInfo(Target::Thread *thread,
                                              StopInfo &stopInfo) {
   BreakpointManager::Site site;

--- a/Sources/Core/HardwareBreakpointManager.cpp
+++ b/Sources/Core/HardwareBreakpointManager.cpp
@@ -41,12 +41,13 @@ ErrorCode HardwareBreakpointManager::add(Address const &address,
 }
 
 ErrorCode HardwareBreakpointManager::remove(Address const &address) {
+  CHK(super::remove(address));
+
   auto loc = std::find(_locations.begin(), _locations.end(), address);
   if (loc != _locations.end()) {
     _locations[loc - _locations.begin()] = 0;
   }
-
-  return super::remove(address);
+  return kSuccess;
 }
 
 ErrorCode HardwareBreakpointManager::enableLocation(Site const &site,
@@ -65,9 +66,8 @@ ErrorCode HardwareBreakpointManager::enableLocation(Site const &site,
   }
 
   enumerateThreads(thread, [&](Target::Thread *t) {
-    if (t->state() == Target::Thread::kStopped && !enabled(t)) {
-      error = enableLocation(site, idx, t);
-    }
+    DS2ASSERT(t->state() == Target::Thread::kStopped);
+    error = enableLocation(site, idx, t);
   });
 
   if (error == kSuccess) {
@@ -87,9 +87,8 @@ ErrorCode HardwareBreakpointManager::disableLocation(Site const &site,
   int idx = loc - _locations.begin();
 
   enumerateThreads(thread, [&](Target::Thread *t) {
-    if (t->state() == Target::Thread::kStopped && enabled(t)) {
-      error = disableLocation(idx, t);
-    }
+    DS2ASSERT(t->state() == Target::Thread::kStopped);
+    error = disableLocation(idx, t);
   });
 
   return error;
@@ -123,30 +122,16 @@ void HardwareBreakpointManager::enumerateThreads(
   }
 }
 
-void HardwareBreakpointManager::enable(Target::Thread *thread) {
-  super::enable(thread);
-
-  enumerateThreads(thread,
-                   [this](Target::Thread *t) { _enabled.insert(t->tid()); });
+ErrorCode HardwareBreakpointManager::addThread(Target::Thread *thread) {
+  for (auto &site : _sites) {
+    CHK(enableLocation(site.second, thread));
+  }
+  return kSuccess;
 }
 
-void HardwareBreakpointManager::disable(Target::Thread *thread) {
-  super::disable(thread);
-
-  enumerateThreads(thread,
-                   [this](Target::Thread *t) { _enabled.erase(t->tid()); });
-}
-
+// Hardware breakpoints are always enabled
 bool HardwareBreakpointManager::enabled(Target::Thread *thread) const {
-  bool isEnabled = true;
-
-  enumerateThreads(thread, [this, &isEnabled](Target::Thread *t) {
-    if (_enabled.count(t->tid()) == 0) {
-      isEnabled = false;
-    }
-  });
-
-  return isEnabled;
+  return true;
 }
 
 bool HardwareBreakpointManager::fillStopInfo(Target::Thread *thread,

--- a/Sources/Core/SoftwareBreakpointManager.cpp
+++ b/Sources/Core/SoftwareBreakpointManager.cpp
@@ -101,9 +101,9 @@ void SoftwareBreakpointManager::afterResume() {
   //
   auto it = _sites.begin();
   while (it != _sites.end()) {
-    it->second.type =
-        static_cast<Type>(it->second.type & ~kTypeTemporaryOneShot);
-    if (!it->second.type) {
+    it->second.lifetime = static_cast<Lifetime>(it->second.lifetime &
+                                                ~Lifetime::TemporaryOneShot);
+    if (it->second.lifetime == Lifetime::None) {
       // refs should always be 0 unless we have a kTypePermanent breakpoint.
       DS2ASSERT(it->second.refs == 0);
       disableLocation(it->second);

--- a/Sources/Target/Common/ProcessBase.cpp
+++ b/Sources/Target/Common/ProcessBase.cpp
@@ -226,6 +226,11 @@ ErrorCode ProcessBase::readMemoryBuffer(Address const &address, size_t length,
     return error;
   }
 
+  SoftwareBreakpointManager *bpm = softwareBreakpointManager();
+  if (bpm) {
+    bpm->insertStashedInsns(address, length, buffer);
+  }
+
   buffer.resize(nread);
   return kSuccess;
 }

--- a/Sources/Target/Common/ProcessBase.cpp
+++ b/Sources/Target/Common/ProcessBase.cpp
@@ -291,14 +291,6 @@ ErrorCode ProcessBase::beforeResume() {
   if (!isAlive())
     return kErrorProcessNotFound;
 
-  //
-  // Enable software breakpoints.
-  //
-  SoftwareBreakpointManager *bpm = softwareBreakpointManager();
-  if (bpm) {
-    bpm->enable();
-  }
-
   enumerateThreads([&](Thread *thread) { thread->beforeResume(); });
 
   return kSuccess;
@@ -309,7 +301,7 @@ ErrorCode ProcessBase::afterResume() {
     return kSuccess;
   }
 
-  // Disable breakpoints and try to hit software breakpoints.
+  // Try to hit software breakpoints and clear temporary breakpoints.
   SoftwareBreakpointManager *bpm = softwareBreakpointManager();
   if (bpm) {
     for (auto it : _threads) {
@@ -318,7 +310,7 @@ ErrorCode ProcessBase::afterResume() {
         DS2LOG(Debug, "hit breakpoint for tid %" PRI_PID, it.second->tid());
       }
     }
-    bpm->disable();
+    bpm->afterResume();
   }
 
   return kSuccess;

--- a/Sources/Target/Common/ProcessBase.cpp
+++ b/Sources/Target/Common/ProcessBase.cpp
@@ -289,8 +289,8 @@ ErrorCode ProcessBase::beforeResume() {
   //
   // Enable software breakpoints.
   //
-  BreakpointManager *bpm = softwareBreakpointManager();
-  if (bpm != nullptr) {
+  SoftwareBreakpointManager *bpm = softwareBreakpointManager();
+  if (bpm) {
     bpm->enable();
   }
 
@@ -305,20 +305,15 @@ ErrorCode ProcessBase::afterResume() {
   }
 
   // Disable breakpoints and try to hit software breakpoints.
-  BreakpointManager *swBpm = softwareBreakpointManager();
-  if (swBpm != nullptr) {
+  SoftwareBreakpointManager *bpm = softwareBreakpointManager();
+  if (bpm) {
     for (auto it : _threads) {
       BreakpointManager::Site site;
-      if (swBpm->hit(it.second, site) >= 0) {
+      if (bpm->hit(it.second, site) >= 0) {
         DS2LOG(Debug, "hit breakpoint for tid %" PRI_PID, it.second->tid());
       }
     }
-    swBpm->disable();
-  }
-
-  BreakpointManager *hwBpm = hardwareBreakpointManager();
-  if (hwBpm != nullptr) {
-    hwBpm->disable();
+    bpm->disable();
   }
 
   return kSuccess;
@@ -344,7 +339,7 @@ HardwareBreakpointManager *ProcessBase::hardwareBreakpointManager() const {
 
 void ProcessBase::prepareForDetach() {
   SoftwareBreakpointManager *bpm = softwareBreakpointManager();
-  if (bpm != nullptr) {
+  if (bpm) {
     bpm->clear();
   }
 }

--- a/Sources/Target/Common/ThreadBase.cpp
+++ b/Sources/Target/Common/ThreadBase.cpp
@@ -32,9 +32,9 @@ ErrorCode ThreadBase::modifyRegisters(
 }
 
 ErrorCode ThreadBase::beforeResume() {
-  BreakpointManager *bpm = _process->hardwareBreakpointManager();
-  if (bpm != nullptr) {
-    bpm->enable((Target::Thread *)this);
+  HardwareBreakpointManager *bpm = _process->hardwareBreakpointManager();
+  if (bpm) {
+    return bpm->addThread((Target::Thread *)this);
   }
 
   return kSuccess;


### PR DESCRIPTION
Software stoppoints are disabled on each stop/resume, in order to
preserve accuracy of memory reads in the TEXT section. This is
unnecessary for hardware stoppoints, which don't modify user data.