### PR TITLE
Add typesafe bitwise enums and convert Lifetime to use it

### DIFF
--- a/Headers/DebugServer2/Core/BreakpointManager.h
+++ b/Headers/DebugServer2/Core/BreakpointManager.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "DebugServer2/Target/ProcessDecl.h"
+#include "DebugServer2/Utils/Enums.h"
 
 #include <functional>
 
@@ -18,10 +19,11 @@ namespace ds2 {
 
 class BreakpointManager {
 public:
-  enum Lifetime : unsigned int {
-    kLifetimePermanent = (1 << 0),
-    kLifetimeTemporaryOneShot = (1 << 1),
-    kLifetimeTemporaryUntilHit = (1 << 2),
+  enum class Lifetime : unsigned int {
+    None = 0,
+    Permanent = (1 << 0),
+    TemporaryOneShot = (1 << 1),
+    TemporaryUntilHit = (1 << 2),
   };
 
   enum Mode {
@@ -109,3 +111,4 @@ public:
   virtual bool fillStopInfo(Target::Thread *thread, StopInfo &stopInfo) = 0;
 };
 } // namespace ds2
+ENABLE_BITMASK_OPERATORS(ds2::BreakpointManager::Lifetime);

--- a/Headers/DebugServer2/Utils/Enums.h
+++ b/Headers/DebugServer2/Utils/Enums.h
@@ -1,0 +1,48 @@
+//
+// Copyright (c) 2014-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the University of Illinois/NCSA Open
+// Source License found in the LICENSE file in the root directory of this
+// source tree. An additional grant of patent rights can be found in the
+// PATENTS file in the same directory.
+//
+
+template <typename Enum> struct EnableBitMaskOperators {
+  static const bool enable = false;
+};
+
+template <typename Enum>
+typename std::enable_if<EnableBitMaskOperators<Enum>::enable, Enum>::type
+operator|(Enum lhs, Enum rhs) {
+  using underlying = typename std::underlying_type<Enum>::type;
+  return static_cast<Enum>(static_cast<underlying>(lhs) |
+                           static_cast<underlying>(rhs));
+}
+
+template <typename Enum>
+typename std::enable_if<EnableBitMaskOperators<Enum>::enable, Enum>::type
+operator&(Enum lhs, Enum rhs) {
+  using underlying = typename std::underlying_type<Enum>::type;
+  return static_cast<Enum>(static_cast<underlying>(lhs) &
+                           static_cast<underlying>(rhs));
+}
+
+template <typename Enum>
+typename std::enable_if<EnableBitMaskOperators<Enum>::enable, Enum>::type
+operator~(Enum e) {
+  using underlying = typename std::underlying_type<Enum>::type;
+  return static_cast<Enum>(~static_cast<underlying>(e));
+}
+
+template <typename Enum>
+typename std::enable_if<EnableBitMaskOperators<Enum>::enable, Enum>::type
+operator!(Enum e) {
+  using underlying = typename std::underlying_type<Enum>::type;
+  return static_cast<Enum>(!static_cast<underlying>(e));
+}
+
+#define ENABLE_BITMASK_OPERATORS(x)                                            \
+  template <> struct EnableBitMaskOperators<x> {                               \
+    static const bool enable = true;                                           \
+  };

--- a/Headers/DebugServer2/Utils/Enums.h
+++ b/Headers/DebugServer2/Utils/Enums.h
@@ -13,33 +13,37 @@ template <typename Enum> struct EnableBitMaskOperators {
 };
 
 template <typename Enum>
-typename std::enable_if<EnableBitMaskOperators<Enum>::enable, Enum>::type
+typename std::enable_if<EnableBitMaskOperators<Enum>::enable,
+                        Enum>::type constexpr
 operator|(Enum lhs, Enum rhs) {
-  using underlying = typename std::underlying_type<Enum>::type;
-  return static_cast<Enum>(static_cast<underlying>(lhs) |
-                           static_cast<underlying>(rhs));
+  using Underlying = typename std::underlying_type<Enum>::type;
+  return static_cast<Enum>(static_cast<Underlying>(lhs) |
+                           static_cast<Underlying>(rhs));
 }
 
 template <typename Enum>
-typename std::enable_if<EnableBitMaskOperators<Enum>::enable, Enum>::type
+typename std::enable_if<EnableBitMaskOperators<Enum>::enable,
+                        Enum>::type constexpr
 operator&(Enum lhs, Enum rhs) {
-  using underlying = typename std::underlying_type<Enum>::type;
-  return static_cast<Enum>(static_cast<underlying>(lhs) &
-                           static_cast<underlying>(rhs));
+  using Underlying = typename std::underlying_type<Enum>::type;
+  return static_cast<Enum>(static_cast<Underlying>(lhs) &
+                           static_cast<Underlying>(rhs));
 }
 
 template <typename Enum>
-typename std::enable_if<EnableBitMaskOperators<Enum>::enable, Enum>::type
+typename std::enable_if<EnableBitMaskOperators<Enum>::enable,
+                        Enum>::type constexpr
 operator~(Enum e) {
-  using underlying = typename std::underlying_type<Enum>::type;
-  return static_cast<Enum>(~static_cast<underlying>(e));
+  using Underlying = typename std::underlying_type<Enum>::type;
+  return static_cast<Enum>(~static_cast<Underlying>(e));
 }
 
 template <typename Enum>
-typename std::enable_if<EnableBitMaskOperators<Enum>::enable, Enum>::type
+typename std::enable_if<EnableBitMaskOperators<Enum>::enable,
+                        Enum>::type constexpr
 operator!(Enum e) {
-  using underlying = typename std::underlying_type<Enum>::type;
-  return static_cast<Enum>(!static_cast<underlying>(e));
+  using Underlying = typename std::underlying_type<Enum>::type;
+  return static_cast<Enum>(!static_cast<Underlying>(e));
 }
 
 #define ENABLE_BITMASK_OPERATORS(x)                                            \

--- a/Sources/Architecture/ARM/SoftwareSingleStep.cpp
+++ b/Sources/Architecture/ARM/SoftwareSingleStep.cpp
@@ -338,13 +338,13 @@ ErrorCode PrepareSoftwareSingleStep(Process *process,
 
   if (branchPC != static_cast<uint32_t>(-1)) {
     DS2ASSERT(branchPCSize != 0);
-    CHK(manager->add(branchPC, BreakpointManager::kLifetimeTemporaryOneShot,
+    CHK(manager->add(branchPC, BreakpointManager::Lifetime::TemporaryOneShot,
                      branchPCSize, BreakpointManager::kModeExec));
   }
 
   if (nextPC != static_cast<uint32_t>(-1)) {
     DS2ASSERT(nextPCSize != 0);
-    CHK(manager->add(nextPC, BreakpointManager::kLifetimeTemporaryOneShot,
+    CHK(manager->add(nextPC, BreakpointManager::Lifetime::TemporaryOneShot,
                      nextPCSize, BreakpointManager::kModeExec));
   }
 

--- a/Sources/GDBRemote/DebugSessionImpl.cpp
+++ b/Sources/GDBRemote/DebugSessionImpl.cpp
@@ -1095,7 +1095,7 @@ ErrorCode DebugSessionImplBase::onInsertBreakpoint(
   if (bpm == nullptr)
     return kErrorUnsupported;
 
-  return bpm->add(address, BreakpointManager::kLifetimePermanent, size, mode);
+  return bpm->add(address, BreakpointManager::Lifetime::Permanent, size, mode);
 }
 
 ErrorCode DebugSessionImplBase::onRemoveBreakpoint(Session &session,


### PR DESCRIPTION
Previously an enum life `Lifetime` was declared as a trio of `unsigned int`s with some support from the compiler to suggest that you don't use them incorrectly. However, C++11 introduced `enum class`es various template techniques to make this more typesafe.

1. Convert `BreakpointManager::Lifetime` from a bare `enum` to an `enum class`.
2. Template instantiate the necessary bitwise operators for the bitwise mathematics done in `BreakpointManager` (Headers/DebugServer2/Core/BreakpointManager.h:115).
3. Convert the usage sites of `Lifetime` to the new format. 