### PR TITLE
Add arm64 to CircleCI Dockerfile

### DIFF
--- a/Support/Testing/CircleCI/Dockerfile
+++ b/Support/Testing/CircleCI/Dockerfile
@@ -87,4 +87,5 @@ RUN /tmp/install-cmake.sh
 RUN apt-get install -y default-jdk
 COPY Support/Scripts/install-android-emulator.sh /tmp
 RUN /tmp/install-android-emulator.sh arm
+RUN /tmp/install-android-emulator.sh arm64
 RUN /tmp/install-android-emulator.sh x86


### PR DESCRIPTION
Add arm64 to the CircleCI Dockerfile to enable aarch64 testing