### PR TITLE
Add a blacklisted test for android-arm64

### DIFF
--- a/Support/Scripts/run-lldb-tests.sh
+++ b/Support/Scripts/run-lldb-tests.sh
@@ -239,6 +239,9 @@ if [[ "${PLATFORM-}" = "1" ]]; then
     if ! $opt_no_ds2_blacklists; then
       args+=("--excluded" "$blacklist_dir/ds2/android.blacklist")
       args+=("--excluded" "$blacklist_dir/ds2/android_invalid_tests.blacklist")
+      if [[ "$TARGET" = 'Android-ARM64' ]]; then
+        args+=("--excluded" "$blacklist_dir/ds2/android-arm64.blacklist")
+      fi
     fi
   fi
 

--- a/Support/Testing/Blacklists/ds2/android-arm64.blacklist
+++ b/Support/Testing/Blacklists/ds2/android-arm64.blacklist
@@ -1,0 +1,3 @@
+skip
+CreateAfterAttachTestCase.test_create_after_attach_with_popen
+TestReturnValue.ReturnValueTestCase


### PR DESCRIPTION
TestReturnValue.ReturnValueTestCase segfaults and causes a core dump,
thus:

Disable it to enable the test suite to continue.