### PR TITLE
Update minimum cmake to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 ## PATENTS file in the same directory.
 ##
 
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.10)
 cmake_policy(SET CMP0054 NEW)
 set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 


### PR DESCRIPTION
3.7 doesn't handle the android-ndk properly and can't find various c headers e.g. math.h, stdio.h. I'm not sure if 3.7.1..<3.10 will suffice, but since we have the install script for 3.10 in the repo I just chose 3.10.