### PR TITLE
Lower cmake required version to 3.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 ## PATENTS file in the same directory.
 ##
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.9)
 cmake_policy(SET CMP0054 NEW)
 set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 


### PR DESCRIPTION
I don't think we actually need 3.10, and some build hosts we have
internally use cmake 3.9.