### PR TITLE
Remove double ;; from macros

### DIFF
--- a/Headers/DebugServer2/Target/ProcessDecl.h
+++ b/Headers/DebugServer2/Target/ProcessDecl.h
@@ -16,7 +16,7 @@
   namespace TARGET {                                                           \
   class NAME;                                                                  \
   }                                                                            \
-  using TARGET::NAME;
+  using TARGET::NAME
 
 namespace ds2 {
 namespace Target {

--- a/Headers/DebugServer2/Utils/Enums.h
+++ b/Headers/DebugServer2/Utils/Enums.h
@@ -49,4 +49,4 @@ operator!(Enum e) {
 #define ENABLE_BITMASK_OPERATORS(x)                                            \
   template <> struct EnableBitMaskOperators<x> {                               \
     static const bool enable = true;                                           \
-  };
+  }


### PR DESCRIPTION
These macros included a semicolon at the end of their definition which clang7 now complains about the double `;;` when the macro was used in source. 

    ../Headers/DebugServer2/Target/ProcessDecl.h:28:33: error: extra ';' outside of a 
        function is incompatible with C++98 [-Werror,-Wc++98-compat-extra-semi]
        __FORWARD_DECLARE(Linux, Thread);
                                        ^