### PR TITLE
Change DS2LOG to use the proper compiler builtin function string

### DIFF
--- a/Headers/DebugServer2/Utils/Log.h
+++ b/Headers/DebugServer2/Utils/Log.h
@@ -50,14 +50,16 @@ void Log(int level, char const *classname, char const *funcname,
 
 #define PRI_PTR_CAST(VAL) ((uintptr_t)(VAL))
 
-#if defined(__DS2_LOG_CLASS_NAME__)
-#define DS2LOG(LVL, ...)                                                       \
-  ds2::Log(ds2::kLogLevel##LVL, __DS2_LOG_CLASS_NAME__, __FUNCTION__,          \
-           __VA_ARGS__)
+#if defined(COMPILER_MSVC)
+#define FUNCTION_NAME __FUNCTION__
+#elif defined(COMPILER_CLANG) || defined(COMPILER_GCC)
+#define FUNCTION_NAME __PRETTY_FUNCTION__
 #else
-#define DS2LOG(LVL, ...)                                                       \
-  ds2::Log(ds2::kLogLevel##LVL, nullptr, __FUNCTION__, __VA_ARGS__)
+#error "Compiler not supported."
 #endif
+
+#define DS2LOG(LVL, ...)                                                       \
+  ds2::Log(ds2::kLogLevel##LVL, nullptr, FUNCTION_NAME, __VA_ARGS__)
 
 #if !defined(NDEBUG)
 #define DS2ASSERT(COND)                                                        \

--- a/Sources/Core/ARM/SoftwareBreakpointManager.cpp
+++ b/Sources/Core/ARM/SoftwareBreakpointManager.cpp
@@ -8,8 +8,6 @@
 // PATENTS file in the same directory.
 //
 
-#define __DS2_LOG_CLASS_NAME__ "SoftwareBreakpointManager"
-
 #include "DebugServer2/Core/SoftwareBreakpointManager.h"
 #include "DebugServer2/Architecture/ARM/Branching.h"
 #include "DebugServer2/Target/Process.h"

--- a/Sources/Core/SoftwareBreakpointManager.cpp
+++ b/Sources/Core/SoftwareBreakpointManager.cpp
@@ -8,8 +8,6 @@
 // PATENTS file in the same directory.
 //
 
-#define __DS2_LOG_CLASS_NAME__ "SoftwareBreakpointManager"
-
 #include "DebugServer2/Core/SoftwareBreakpointManager.h"
 #include "DebugServer2/Target/Process.h"
 #include "DebugServer2/Target/Thread.h"

--- a/Sources/Core/X86/SoftwareBreakpointManager.cpp
+++ b/Sources/Core/X86/SoftwareBreakpointManager.cpp
@@ -8,8 +8,6 @@
 // PATENTS file in the same directory.
 //
 
-#define __DS2_LOG_CLASS_NAME__ "SoftwareBreakpointManager"
-
 #include "DebugServer2/Core/SoftwareBreakpointManager.h"
 #include "DebugServer2/Target/Thread.h"
 #include "DebugServer2/Utils/Log.h"

--- a/Sources/GDBRemote/DebugSessionImpl.cpp
+++ b/Sources/GDBRemote/DebugSessionImpl.cpp
@@ -8,8 +8,6 @@
 // PATENTS file in the same directory.
 //
 
-#define __DS2_LOG_CLASS_NAME__ "DebugSession"
-
 #include "DebugServer2/GDBRemote/DebugSessionImpl.h"
 #include "DebugServer2/Core/HardwareBreakpointManager.h"
 #include "DebugServer2/Core/SoftwareBreakpointManager.h"

--- a/Sources/GDBRemote/PlatformSessionImpl.cpp
+++ b/Sources/GDBRemote/PlatformSessionImpl.cpp
@@ -8,8 +8,6 @@
 // PATENTS file in the same directory.
 //
 
-#define __DS2_LOG_CLASS_NAME__ "PlatformSession"
-
 #include "DebugServer2/GDBRemote/PlatformSessionImpl.h"
 #include "DebugServer2/GDBRemote/Session.h"
 #include "DebugServer2/Host/Platform.h"

--- a/Sources/GDBRemote/ProtocolInterpreter.cpp
+++ b/Sources/GDBRemote/ProtocolInterpreter.cpp
@@ -8,8 +8,6 @@
 // PATENTS file in the same directory.
 //
 
-#define __DS2_LOG_CLASS_NAME__ "ProtocolInterpreter"
-
 #include "DebugServer2/GDBRemote/ProtocolInterpreter.h"
 #include "DebugServer2/GDBRemote/ProtocolHelpers.h"
 #include "DebugServer2/GDBRemote/Session.h"

--- a/Sources/GDBRemote/Session.cpp
+++ b/Sources/GDBRemote/Session.cpp
@@ -8,8 +8,6 @@
 // PATENTS file in the same directory.
 //
 
-#define __DS2_LOG_CLASS_NAME__ "Session"
-
 #include "DebugServer2/GDBRemote/Session.h"
 #include "DebugServer2/GDBRemote/ProtocolHelpers.h"
 #include "DebugServer2/GDBRemote/SessionDelegate.h"

--- a/Sources/GDBRemote/SessionBase.cpp
+++ b/Sources/GDBRemote/SessionBase.cpp
@@ -8,8 +8,6 @@
 // PATENTS file in the same directory.
 //
 
-#define __DS2_LOG_CLASS_NAME__ "Session"
-
 #include "DebugServer2/GDBRemote/SessionBase.h"
 #include "DebugServer2/GDBRemote/ProtocolHelpers.h"
 #include "DebugServer2/Utils/HexValues.h"

--- a/Sources/GDBRemote/SlaveSessionImpl.cpp
+++ b/Sources/GDBRemote/SlaveSessionImpl.cpp
@@ -8,8 +8,6 @@
 // PATENTS file in the same directory.
 //
 
-#define __DS2_LOG_CLASS_NAME__ "SlaveSession"
-
 #include "DebugServer2/GDBRemote/SlaveSessionImpl.h"
 
 namespace ds2 {

--- a/Sources/Host/Darwin/Mach.cpp
+++ b/Sources/Host/Darwin/Mach.cpp
@@ -8,8 +8,6 @@
 // PATENTS file in the same directory.
 //
 
-#define __DS2_LOG_CLASS_NAME__ "Mach"
-
 #include "DebugServer2/Host/Darwin/Mach.h"
 #include "DebugServer2/Host/Platform.h"
 #include "DebugServer2/Utils/Log.h"

--- a/Sources/Host/Darwin/PTrace.cpp
+++ b/Sources/Host/Darwin/PTrace.cpp
@@ -9,8 +9,6 @@
 // PATENTS file in the same directory.
 //
 
-#define __DS2_LOG_CLASS_NAME__ "PTrace"
-
 #include "DebugServer2/Host/Darwin/PTrace.h"
 #include "DebugServer2/Host/Platform.h"
 #include "DebugServer2/Utils/Log.h"

--- a/Sources/Host/FreeBSD/PTrace.cpp
+++ b/Sources/Host/FreeBSD/PTrace.cpp
@@ -9,8 +9,6 @@
 // PATENTS file in the same directory.
 //
 
-#define __DS2_LOG_CLASS_NAME__ "PTrace"
-
 #include "DebugServer2/Host/FreeBSD/PTrace.h"
 #include "DebugServer2/Host/Platform.h"
 #include "DebugServer2/Utils/Log.h"

--- a/Sources/Host/Linux/PTrace.cpp
+++ b/Sources/Host/Linux/PTrace.cpp
@@ -8,8 +8,6 @@
 // PATENTS file in the same directory.
 //
 
-#define __DS2_LOG_CLASS_NAME__ "PTrace"
-
 #include "DebugServer2/Host/Linux/PTrace.h"
 #include "DebugServer2/Host/Linux/ExtraWrappers.h"
 #include "DebugServer2/Host/Platform.h"

--- a/Sources/Host/POSIX/ProcessSpawner.cpp
+++ b/Sources/Host/POSIX/ProcessSpawner.cpp
@@ -8,8 +8,6 @@
 // PATENTS file in the same directory.
 //
 
-#define __DS2_LOG_CLASS_NAME__ "ProcessSpawner"
-
 #include "DebugServer2/Base.h"
 #if defined(OS_LINUX)
 #include "DebugServer2/Host/Linux/ExtraWrappers.h"

--- a/Sources/Host/Windows/ProcessSpawner.cpp
+++ b/Sources/Host/Windows/ProcessSpawner.cpp
@@ -8,8 +8,6 @@
 // PATENTS file in the same directory.
 //
 
-#define __DS2_LOG_CLASS_NAME__ "ProcessSpawner"
-
 #include "DebugServer2/Host/ProcessSpawner.h"
 #include "DebugServer2/Host/Platform.h"
 #include "DebugServer2/Host/Windows/ExtraWrappers.h"

--- a/Sources/Target/Common/ProcessBase.cpp
+++ b/Sources/Target/Common/ProcessBase.cpp
@@ -8,8 +8,6 @@
 // PATENTS file in the same directory.
 //
 
-#define __DS2_LOG_CLASS_NAME__ "Target::ProcessBase"
-
 #include "DebugServer2/Target/ProcessBase.h"
 #include "DebugServer2/Architecture/CPUState.h"
 #include "DebugServer2/Core/SoftwareBreakpointManager.h"

--- a/Sources/Target/Darwin/Process.cpp
+++ b/Sources/Target/Darwin/Process.cpp
@@ -8,8 +8,6 @@
 // PATENTS file in the same directory.
 //
 
-#define __DS2_LOG_CLASS_NAME__ "Target::Process"
-
 #include "DebugServer2/Target/Process.h"
 #include "DebugServer2/Core/BreakpointManager.h"
 #include "DebugServer2/Host/Darwin/LibProc.h"

--- a/Sources/Target/Darwin/Thread.cpp
+++ b/Sources/Target/Darwin/Thread.cpp
@@ -9,8 +9,6 @@
 // PATENTS file in the same directory.
 //
 
-#define __DS2_LOG_CLASS_NAME__ "Target::Thread"
-
 #include "DebugServer2/Target/Darwin/Thread.h"
 #include "DebugServer2/Architecture/CPUState.h"
 #include "DebugServer2/Host/Darwin/PTrace.h"

--- a/Sources/Target/Darwin/X86_64/ThreadX86_64.cpp
+++ b/Sources/Target/Darwin/X86_64/ThreadX86_64.cpp
@@ -9,8 +9,6 @@
 // PATENTS file in the same directory.
 //
 
-#define __DS2_LOG_CLASS_NAME__ "Target::Thread"
-
 #include "DebugServer2/Target/Darwin/Thread.h"
 #include "DebugServer2/Architecture/CPUState.h"
 

--- a/Sources/Target/FreeBSD/Process.cpp
+++ b/Sources/Target/FreeBSD/Process.cpp
@@ -8,8 +8,6 @@
 // PATENTS file in the same directory.
 //
 
-#define __DS2_LOG_CLASS_NAME__ "Target::Process"
-
 #include "DebugServer2/Target/Process.h"
 #include "DebugServer2/Core/BreakpointManager.h"
 #include "DebugServer2/Host/FreeBSD/PTrace.h"

--- a/Sources/Target/FreeBSD/Thread.cpp
+++ b/Sources/Target/FreeBSD/Thread.cpp
@@ -9,8 +9,6 @@
 // PATENTS file in the same directory.
 //
 
-#define __DS2_LOG_CLASS_NAME__ "Target::Thread"
-
 #include "DebugServer2/Target/FreeBSD/Thread.h"
 #include "DebugServer2/Architecture/CPUState.h"
 #include "DebugServer2/Host/FreeBSD/PTrace.h"

--- a/Sources/Target/Linux/Process.cpp
+++ b/Sources/Target/Linux/Process.cpp
@@ -8,8 +8,6 @@
 // PATENTS file in the same directory.
 //
 
-#define __DS2_LOG_CLASS_NAME__ "Target::Process"
-
 #include "DebugServer2/Target/Process.h"
 #include "DebugServer2/Core/BreakpointManager.h"
 #include "DebugServer2/Host/Linux/ExtraWrappers.h"

--- a/Sources/Target/Linux/Thread.cpp
+++ b/Sources/Target/Linux/Thread.cpp
@@ -8,8 +8,6 @@
 // PATENTS file in the same directory.
 //
 
-#define __DS2_LOG_CLASS_NAME__ "Target::Thread"
-
 #include "DebugServer2/Target/Linux/Thread.h"
 #include "DebugServer2/Core/SoftwareBreakpointManager.h"
 #include "DebugServer2/Host/Linux/ExtraWrappers.h"

--- a/Sources/Target/POSIX/Process.cpp
+++ b/Sources/Target/POSIX/Process.cpp
@@ -8,8 +8,6 @@
 // PATENTS file in the same directory.
 //
 
-#define __DS2_LOG_CLASS_NAME__ "Target::Process"
-
 #include "DebugServer2/Target/Process.h"
 #include "DebugServer2/Core/BreakpointManager.h"
 #include "DebugServer2/Host/POSIX/PTrace.h"

--- a/Sources/Target/Windows/ARM/ThreadARM.cpp
+++ b/Sources/Target/Windows/ARM/ThreadARM.cpp
@@ -8,8 +8,6 @@
 // PATENTS file in the same directory.
 //
 
-#define __DS2_LOG_CLASS_NAME__ "Target::Thread"
-
 #include "DebugServer2/Target/Thread.h"
 #include "DebugServer2/Architecture/ARM/SoftwareSingleStep.h"
 #include "DebugServer2/Host/Platform.h"

--- a/Sources/Target/Windows/Process.cpp
+++ b/Sources/Target/Windows/Process.cpp
@@ -8,8 +8,6 @@
 // PATENTS file in the same directory.
 //
 
-#define __DS2_LOG_CLASS_NAME__ "Target::Process"
-
 #include "DebugServer2/Target/Process.h"
 #include "DebugServer2/Host/Platform.h"
 #include "DebugServer2/Host/Windows/ExtraWrappers.h"

--- a/Sources/Target/Windows/Thread.cpp
+++ b/Sources/Target/Windows/Thread.cpp
@@ -8,8 +8,6 @@
 // PATENTS file in the same directory.
 //
 
-#define __DS2_LOG_CLASS_NAME__ "Target::Thread"
-
 #include "DebugServer2/Target/Windows/Thread.h"
 #include "DebugServer2/Host/Platform.h"
 #include "DebugServer2/Host/Windows/ExtraWrappers.h"

--- a/Sources/Target/Windows/X86/ThreadX86.cpp
+++ b/Sources/Target/Windows/X86/ThreadX86.cpp
@@ -8,8 +8,6 @@
 // PATENTS file in the same directory.
 //
 
-#define __DS2_LOG_CLASS_NAME__ "Target::Thread"
-
 #include "DebugServer2/Target/Thread.h"
 #include "DebugServer2/Architecture/X86/RegisterCopy.h"
 #include "DebugServer2/Host/Platform.h"

--- a/Sources/Target/Windows/X86_64/ThreadX86_64.cpp
+++ b/Sources/Target/Windows/X86_64/ThreadX86_64.cpp
@@ -8,8 +8,6 @@
 // PATENTS file in the same directory.
 //
 
-#define __DS2_LOG_CLASS_NAME__ "Target::Thread"
-
 #include "DebugServer2/Target/Thread.h"
 #include "DebugServer2/Architecture/X86/RegisterCopy.h"
 #include "DebugServer2/Host/Platform.h"


### PR DESCRIPTION
DS2LOG uses __FUNCTION__ which does not accurately refer to the
parent function when you are working with a lambda as shown from this
error message:

    ds2/Sources/Target/Common/ProcessBase.cpp:149:7: warning: inside a
    lambda, '__FUNCTION__' expands to the name of the function call
    operator; consider capturing the name of the enclosing function
    explicitly [misc-lambda-function-name]
          DS2LOG(Debug,
          ^

MSVC's __FUNCTION__ behaves properly while GCC & clang require
__PRETTY_FUNCTION__ to replicate this. Conditionally using the right
version allows us to remove __DS2_LOG_CLASS_NAME__ as well.