### PR TITLE
Revert "Remove temporary patch that was fixed upstream"

### DIFF
--- a/Support/Scripts/run-lldb-tests.sh
+++ b/Support/Scripts/run-lldb-tests.sh
@@ -25,6 +25,11 @@ cherry_pick_patches() {
     patch -d "$lldb_path" -p1 < "$testingPath/Patches/getplatform-workaround.patch"
   fi
 
+  if $opt_pudb; then
+    # This patch is to enable debugging the lldb test suite with PUDB
+    patch -d "$lldb_path" -p1 < "$testingPath/Patches/fix-test-suite-path.patch"
+  fi
+
   cd "$OLDPWD"
 }
 

--- a/Support/Testing/Patches/fix-test-suite-path.patch
+++ b/Support/Testing/Patches/fix-test-suite-path.patch
@@ -1,0 +1,13 @@
+diff --git a/test/use_lldb_suite.py b/test/use_lldb_suite.py
+index 6e24b9d..617af38 100644
+--- a/test/use_lldb_suite.py
++++ b/test/use_lldb_suite.py
+@@ -4,7 +4,7 @@ import sys
+
+
+ def find_lldb_root():
+-    lldb_root = os.path.dirname(inspect.getfile(inspect.currentframe()))
++    lldb_root = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
+     while True:
+         lldb_root = os.path.dirname(lldb_root)
+         if lldb_root is None:


### PR DESCRIPTION
This reverts commit 36cf1426b8b077d975bacba518291d558e992db5.

@xiaobai This patch won't make upstream until `release_80`. Thought it made the cut for 70 but nope.