### PR TITLE
Add cmake install for ds2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -482,3 +482,5 @@ if (STATIC AND DEFINED CMAKE_THREAD_LIBS_INIT AND
 else ()
   target_link_libraries(ds2 ${CMAKE_THREAD_LIBS_INIT})
 endif ()
+
+install(TARGETS ds2 DESTINATION bin)


### PR DESCRIPTION
ds2 is a routinely used binary on Windows that's not attached to our internal toolchain. Having an install target is useful.