### PR TITLE
Fix build for FreeBSD

### DIFF
--- a/Headers/DebugServer2/Target/FreeBSD/Process.h
+++ b/Headers/DebugServer2/Target/FreeBSD/Process.h
@@ -49,8 +49,8 @@ protected:
   ErrorCode updateInfo() override;
   ErrorCode updateAuxiliaryVector() override;
   ErrorCode enumerateAuxiliaryVector(
-      std::function<
-          void(Support::ELFSupport::AuxiliaryVectorEntry const &)> const &cb);
+      std::function<void(Support::ELFSupport::AuxiliaryVectorEntry const
+                             &)> const &cb) override;
 
 protected:
   friend class Thread;


### PR DESCRIPTION
Added `override`.

```
Fixes:

    [ 27%] Building CXX object CMakeFiles/ds2.dir/Sources/Target/Common/ThreadBase.cpp.o
    /usr/bin/c++  -DTEST_FREEBSD_BUILD -I/root/src/ds2/Headers -I/root/src/ds2/Tools/JSObjects/Headers -Wall -Wextra -Werror -Wno-unused-parameter -Wcomma -Wdeprecated -Wextra-semi -Wfloat-equal -Winconsistent-missing-override -Wmissing-prototypes -Wnon-virtual-dtor -Wshadow -std=c++11 -o CMakeFiles/ds2.dir/Sources/Target/Common/ThreadBase.cpp.o -c /root/src/ds2/Sources/Target/Common/ThreadBase.cpp
    In file included from /root/src/ds2/Sources/Target/Common/ThreadBase.cpp:12:
    In file included from /root/src/ds2/Headers/DebugServer2/Target/Process.h:20:
    /root/src/ds2/Headers/DebugServer2/Target/FreeBSD/Process.h:51:13: error: 'enumerateAuxiliaryVector' overrides a member function but is not marked 'override'
          [-Werror,-Winconsistent-missing-override]
      ErrorCode enumerateAuxiliaryVector(
                ^
    /root/src/ds2/Headers/DebugServer2/Target/POSIX/ELFProcess.h:35:21: note: overridden virtual function is here
      virtual ErrorCode enumerateAuxiliaryVector(
                        ^
    1 error generated.
    *** Error code 1
```
