### PR TITLE
Identity is not the same things as equality in Python

### DIFF
--- a/Support/Scripts/tidy.py
+++ b/Support/Scripts/tidy.py
@@ -38,7 +38,7 @@ def run_clang_tidy(ignores: [str], file: str) -> Optional[subprocess.CompletedPr
 
 def get_parent_ccdb_from(path: str) -> Optional[str]:
     current_directory = path
-    while current_directory is not "/":
+    while current_directory != "/":
         if os.path.exists(os.path.join(current_directory, "compile_commands.json")):
             return os.path.join(current_directory, "compile_commands.json")
         else:


### PR DESCRIPTION
Use ==/!= to compare str, bytes, and int literals.
```
>>> slashes = "/"
>>> slashes += "/"
>>> slashes == "//"
True
>>> slashes is "//"
False
```
[flake8](http://flake8.pycqa.org) testing of https://github.com/facebook/ds2 on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./Support/Scripts/tidy.py:41:11: F632 use ==/!= to compare str, bytes, and int literals
    while current_directory is not "/":
          ^
1     F632 use ==/!= to compare str, bytes, and int literals
1
```